### PR TITLE
Move keys to their own object

### DIFF
--- a/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala
@@ -29,6 +29,11 @@ object HeaderPattern {
   val hashLineComment = """(?s)((?:#[^\n\r]*(?:\n|\r|\r\n))+(?:\n|\r|\r\n)+)(.*)""".r
 }
 
+object HeaderKeys {
+  val headers = settingKey[Map[String, (Regex, String)]]("Header pattern and text by extension; empty by default")
+  val createHeaders = taskKey[Iterable[File]]("Create/update headers")
+}
+
 /**
  * Enable this plugin to automate header creation/update on compile. By default the `Compile` and `Test` configurations
  * are considered; use [[AutomateHeaderPlugin.automateFor]] to add further ones.
@@ -40,20 +45,17 @@ object AutomateHeaderPlugin extends AutoPlugin {
   override def projectSettings = automateFor(Compile, Test)
 
   def automateFor(configurations: Configuration*): Seq[Setting[_]] = configurations.foldLeft(List.empty[Setting[_]]) {
-    _ ++ inConfig(_)(compile := compile.dependsOn(HeaderPlugin.autoImport.createHeaders).value)
+    _ ++ inConfig(_)(compile := compile.dependsOn(HeaderKeys.createHeaders).value)
   }
 }
 
 /**
- * This plugin adds the [[HeaderPlugin.autoImport.createHeaders]] task to created/update headers. The patterns and
- * texts for the headers are specified via [[HeaderPlugin.autoImport.headers]].
+ * This plugin adds the [[HeaderKeys.createHeaders]] task to created/update headers. The patterns and
+ * texts for the headers are specified via [[HeaderKeys.headers]].
  */
 object HeaderPlugin extends AutoPlugin {
 
-  object autoImport {
-    val headers = settingKey[Map[String, (Regex, String)]]("Header pattern and text by extension; empty by default")
-    val createHeaders = taskKey[Iterable[File]]("Create/update headers")
-  }
+  val autoImport = HeaderKeys
 
   import autoImport._
 

--- a/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala
@@ -29,7 +29,7 @@ object HeaderPattern {
   val hashLineComment = """(?s)((?:#[^\n\r]*(?:\n|\r|\r\n))+(?:\n|\r|\r\n)+)(.*)""".r
 }
 
-object HeaderKeys {
+object HeaderKey {
   val headers = settingKey[Map[String, (Regex, String)]]("Header pattern and text by extension; empty by default")
   val createHeaders = taskKey[Iterable[File]]("Create/update headers")
 }
@@ -45,17 +45,17 @@ object AutomateHeaderPlugin extends AutoPlugin {
   override def projectSettings = automateFor(Compile, Test)
 
   def automateFor(configurations: Configuration*): Seq[Setting[_]] = configurations.foldLeft(List.empty[Setting[_]]) {
-    _ ++ inConfig(_)(compile := compile.dependsOn(HeaderKeys.createHeaders).value)
+    _ ++ inConfig(_)(compile := compile.dependsOn(HeaderKey.createHeaders).value)
   }
 }
 
 /**
- * This plugin adds the [[HeaderKeys.createHeaders]] task to created/update headers. The patterns and
- * texts for the headers are specified via [[HeaderKeys.headers]].
+ * This plugin adds the [[HeaderKey.createHeaders]] task to created/update headers. The patterns and
+ * texts for the headers are specified via [[HeaderKey.headers]].
  */
 object HeaderPlugin extends AutoPlugin {
 
-  val autoImport = HeaderKeys
+  val autoImport = HeaderKey
 
   import autoImport._
 


### PR DESCRIPTION
This PR does not change anything to the inner working of the plugin, but provides an easier way to reference the keys that are used in the plugin, espcially in `.scala` builds.

The keys can now be imported with: `import de.heikoseeberger.sbtheader.HeaderKeys._`.
`import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport._` still works. 

