### PR TITLE
Allow variants of HeaderPattern for pre-canned Apache 2.0 license

### DIFF
--- a/sbt-header-test/build.sbt
+++ b/sbt-header-test/build.sbt
@@ -1,5 +1,4 @@
 import de.heikoseeberger.sbtheader.HeaderPattern
-import de.heikoseeberger.sbtheader.license.Apache2_0
 
 lazy val sbtHeaderTest = project.in(file(".")).enablePlugins(AutomateHeaderPlugin)
 

--- a/src/main/scala/de/heikoseeberger/sbtheader/license/Apache2_0.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/license/Apache2_0.scala
@@ -20,28 +20,56 @@ package license
 import scala.util.matching.Regex
 
 trait License {
-  def apply(yyyy: String, copyrightOwner: String): (Regex, String)
+  def apply(yyyy: String, copyrightOwner: String, commentStyle: String): (Regex, String)
 }
 
 object Apache2_0 extends License {
-  override def apply(yyyy: String, copyrightOwner: String) = {
-    val text = s"""|/*
-                   | * Copyright $yyyy $copyrightOwner
-                   | *
-                   | * Licensed under the Apache License, Version 2.0 (the "License");
-                   | * you may not use this file except in compliance with the License.
-                   | * You may obtain a copy of the License at
-                   | *
-                   | *     http://www.apache.org/licenses/LICENSE-2.0
-                   | *
-                   | * Unless required by applicable law or agreed to in writing, software
-                   | * distributed under the License is distributed on an "AS IS" BASIS,
-                   | * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                   | * See the License for the specific language governing permissions and
-                   | * limitations under the License.
-                   | */
-                   |
-                   |""".stripMargin
-    (HeaderPattern.cStyleBlockComment, text)
+  import HeaderPattern._
+
+  override def apply(yyyy: String, copyrightOwner: String, commentStyle: String = "*") = {
+    commentStyle match {
+      case "*" =>
+        (
+          cStyleBlockComment,
+          s"""|/*
+              | * Copyright $yyyy $copyrightOwner
+              | *
+              | * Licensed under the Apache License, Version 2.0 (the "License");
+              | * you may not use this file except in compliance with the License.
+              | * You may obtain a copy of the License at
+              | *
+              | *     http://www.apache.org/licenses/LICENSE-2.0
+              | *
+              | * Unless required by applicable law or agreed to in writing, software
+              | * distributed under the License is distributed on an "AS IS" BASIS,
+              | * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+              | * See the License for the specific language governing permissions and
+              | * limitations under the License.
+              | */
+              |
+              |""".stripMargin
+        )
+      case "#" =>
+        (
+          hashLineComment,
+          s"""|# Copyright $yyyy $copyrightOwner
+              |#
+              |# Licensed under the Apache License, Version 2.0 (the "License");
+              |# you may not use this file except in compliance with the License.
+              |# You may obtain a copy of the License at
+              |#
+              |#     http://www.apache.org/licenses/LICENSE-2.0
+              |#
+              |# Unless required by applicable law or agreed to in writing, software
+              |# distributed under the License is distributed on an "AS IS" BASIS,
+              |# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+              |# See the License for the specific language governing permissions and
+              |# limitations under the License.
+              |
+              |""".stripMargin
+        )
+      case _ =>
+        throw new IllegalArgumentException(s"Comment style '$commentStyle' not supported")
+    }
   }
 }

--- a/src/test/scala/de/heikoseeberger/sbtheader/license/Apache2_0Spec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/license/Apache2_0Spec.scala
@@ -16,6 +16,7 @@
 
 package de.heikoseeberger.sbtheader.license
 
+import de.heikoseeberger.sbtheader.HeaderPattern
 import org.scalatest.{ Matchers, WordSpec }
 
 class Apache2_0Spec extends WordSpec with Matchers {
@@ -23,7 +24,7 @@ class Apache2_0Spec extends WordSpec with Matchers {
   "apply" should {
 
     "return the Apache 2.0 license with the given copyright year and owner" in {
-      val (_, apache2_0) = Apache2_0("2015", "Heiko Seeberger")
+      val (headerPattern, apache2_0) = Apache2_0("2015", "Heiko Seeberger")
       val expected =
         s"""|/*
             | * Copyright 2015 Heiko Seeberger
@@ -42,7 +43,36 @@ class Apache2_0Spec extends WordSpec with Matchers {
             | */
             |
             |""".stripMargin
+
       apache2_0 shouldBe expected
+      headerPattern shouldBe HeaderPattern.cStyleBlockComment
+    }
+
+    "return the Apache 2.0 license with hash style" in {
+      val (headerPattern, apache2_0) = Apache2_0("2015", "Heiko Seeberger", "#")
+      val expected =
+        """|# Copyright 2015 Heiko Seeberger
+           |#
+           |# Licensed under the Apache License, Version 2.0 (the "License");
+           |# you may not use this file except in compliance with the License.
+           |# You may obtain a copy of the License at
+           |#
+           |#     http://www.apache.org/licenses/LICENSE-2.0
+           |#
+           |# Unless required by applicable law or agreed to in writing, software
+           |# distributed under the License is distributed on an "AS IS" BASIS,
+           |# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+           |# See the License for the specific language governing permissions and
+           |# limitations under the License.
+           |
+           |""".stripMargin
+
+      apache2_0 shouldBe expected
+      headerPattern shouldBe HeaderPattern.hashLineComment
+    }
+
+    "fail when unknown comment style prefix provided" in {
+      intercept[IllegalArgumentException] { Apache2_0("2015", "Heiko Seeberger", "???") }
     }
   }
 }


### PR DESCRIPTION
Allow variants of HeaderPattern for pre-canned Apache 2.0 license