### PR TITLE
use native newlines

### DIFF
--- a/src/main/scala/de/heikoseeberger/sbtheader/package.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/package.scala
@@ -47,5 +47,5 @@ package object sbtheader {
       }
   }
 
-  val newLine: String = f"%n"
+  val newLine: String = System.getProperty("line.separator")
 }


### PR DESCRIPTION
When I use the plugin on windows all files touched by the plugin are staged by git because the line endings changed.

A more generic solution would probably detect the line endings of the source files and use these for the inserted headers.