### PR TITLE
Update to Java 8 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ sbt-header is an [sbt](http://www.scala-sbt.org) plugin for creating or updating
 
 ## Requirements
 
-- Java 7 or higher
+- Java 8 or higher
 - sbt 0.13.8 or higher
 
 ## Configuration


### PR DESCRIPTION
`sbt-header` requires Java 8 (instead of Java 7 which is currently documented in the README.md) because it uses the `java.nio.file.Files` object which got introduced in Java 8: https://github.com/sbt/sbt-header/blob/master/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala#L102