### PR TITLE
BSD licenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,12 @@ headers := Map(
 )
 ```
 
-The Apache 2.0 license has been pre-canned in [Apache2_0](https://github.com/sbt/sbt-header/blob/master/src/main/scala/de/heikoseeberger/sbtheader/license/Apache2_0.scala) and can be added as follows:
+Three licenses have been pre-canned in [License](https://github.com/sbt/sbt-header/blob/master/src/main/scala/de/heikoseeberger/sbtheader/license/License.scala):
+- [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+- [MIT License](https://opensource.org/licenses/MIT)
+- BSD [2 Clause](https://opensource.org/licenses/BSD-2-Clause) and [3 Clause](https://opensource.org/licenses/BSD-3-Clause) License
+
+They can be added as follows:
 
 ``` scala
 import de.heikoseeberger.sbtheader.license.Apache2_0

--- a/src/main/scala/de/heikoseeberger/sbtheader/license/License.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/license/License.scala
@@ -76,3 +76,32 @@ object MIT extends License {
         |""".stripMargin
   }
 }
+
+object BSD2Clause extends License {
+  override def createLicenseText(yyyy: String, copyrightOwner: String) = {
+    s"""|Copyright (c) $yyyy, $copyrightOwner
+        |All rights reserved.
+        |
+        |Redistribution and use in source and binary forms, with or without modification,
+        |are permitted provided that the following conditions are met:
+        |
+        |1. Redistributions of source code must retain the above copyright notice, this
+        |list of conditions and the following disclaimer.
+        |
+        |2. Redistributions in binary form must reproduce the above copyright notice,
+        |this list of conditions and the following disclaimer in the documentation and/or
+        |other materials provided with the distribution.
+        |
+        |THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+        |ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+        |WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+        |DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+        |ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+        |(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+        |LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+        |ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+        |(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+        |SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+        |""".stripMargin
+  }
+}

--- a/src/main/scala/de/heikoseeberger/sbtheader/license/License.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/license/License.scala
@@ -105,3 +105,36 @@ object BSD2Clause extends License {
         |""".stripMargin
   }
 }
+
+object BSD3Clause extends License {
+  override def createLicenseText(yyyy: String, copyrightOwner: String) = {
+    s"""|Copyright (c) $yyyy, $copyrightOwner
+        |All rights reserved.
+        |
+        |Redistribution and use in source and binary forms, with or without modification,
+        |are permitted provided that the following conditions are met:
+        |
+        |1. Redistributions of source code must retain the above copyright notice, this
+        |list of conditions and the following disclaimer.
+        |
+        |2. Redistributions in binary form must reproduce the above copyright notice,
+        |this list of conditions and the following disclaimer in the documentation and/or
+        |other materials provided with the distribution.
+        |
+        |3. Neither the name of the copyright holder nor the names of its contributors
+        |may be used to endorse or promote products derived from this software without
+        |specific prior written permission.
+        |
+        |THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+        |ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+        |WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+        |DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+        |ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+        |(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+        |LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+        |ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+        |(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+        |SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+        |""".stripMargin
+  }
+}

--- a/src/test/scala/de/heikoseeberger/sbtheader/license/BSD2ClauseSpec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/license/BSD2ClauseSpec.scala
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.heikoseeberger.sbtheader.license
+
+import de.heikoseeberger.sbtheader.HeaderPattern
+import org.scalatest.{ Matchers, WordSpec }
+
+class BSD2ClauseSpec extends WordSpec with Matchers {
+
+  "apply" should {
+
+    "return the BSD 2 Clause license with the given copyright year and owner" in {
+      val (headerPattern, mit) = BSD2Clause("2015", "Heiko Seeberger")
+      val expected =
+        s"""|/*
+            | * Copyright (c) 2015, Heiko Seeberger
+            | * All rights reserved.
+            | *
+            | * Redistribution and use in source and binary forms, with or without modification,
+            | * are permitted provided that the following conditions are met:
+            | *
+            | * 1. Redistributions of source code must retain the above copyright notice, this
+            | * list of conditions and the following disclaimer.
+            | *
+            | * 2. Redistributions in binary form must reproduce the above copyright notice,
+            | * this list of conditions and the following disclaimer in the documentation and/or
+            | * other materials provided with the distribution.
+            | *
+            | * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+            | * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+            | * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+            | * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+            | * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+            | * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+            | * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+            | * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+            | * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+            | * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+            | */
+            |
+            |""".stripMargin
+
+      mit shouldBe expected
+      headerPattern shouldBe HeaderPattern.cStyleBlockComment
+    }
+
+    "return the BSD 2 Clause license with hash style" in {
+      val (headerPattern, mit) = BSD2Clause("2015", "Heiko Seeberger", "#")
+      val expected =
+        s"""|# Copyright (c) 2015, Heiko Seeberger
+            |# All rights reserved.
+            |#
+            |# Redistribution and use in source and binary forms, with or without modification,
+            |# are permitted provided that the following conditions are met:
+            |#
+            |# 1. Redistributions of source code must retain the above copyright notice, this
+            |# list of conditions and the following disclaimer.
+            |#
+            |# 2. Redistributions in binary form must reproduce the above copyright notice,
+            |# this list of conditions and the following disclaimer in the documentation and/or
+            |# other materials provided with the distribution.
+            |#
+            |# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+            |# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+            |# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+            |# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+            |# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+            |# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+            |# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+            |# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+            |# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+            |# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+            |
+            |""".stripMargin
+
+      mit shouldBe expected
+      headerPattern shouldBe HeaderPattern.hashLineComment
+    }
+
+    "fail when unknown comment style prefix provided" in {
+      intercept[IllegalArgumentException] { BSD2Clause("2015", "Heiko Seeberger", "???") }
+    }
+  }
+}

--- a/src/test/scala/de/heikoseeberger/sbtheader/license/BSD3ClauseSpec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/license/BSD3ClauseSpec.scala
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.heikoseeberger.sbtheader.license
+
+import de.heikoseeberger.sbtheader.HeaderPattern
+import org.scalatest.{Matchers, WordSpec}
+
+class BSD3ClauseSpec extends WordSpec with Matchers {
+
+  "apply" should {
+
+    "return the BSD 3 Clause license with the given copyright year and owner" in {
+      val (headerPattern, mit) = BSD3Clause("2015", "Heiko Seeberger")
+      val expected =
+        s"""|/*
+            | * Copyright (c) 2015, Heiko Seeberger
+            | * All rights reserved.
+            | *
+            | * Redistribution and use in source and binary forms, with or without modification,
+            | * are permitted provided that the following conditions are met:
+            | *
+            | * 1. Redistributions of source code must retain the above copyright notice, this
+            | * list of conditions and the following disclaimer.
+            | *
+            | * 2. Redistributions in binary form must reproduce the above copyright notice,
+            | * this list of conditions and the following disclaimer in the documentation and/or
+            | * other materials provided with the distribution.
+            | *
+            | * 3. Neither the name of the copyright holder nor the names of its contributors
+            | * may be used to endorse or promote products derived from this software without
+            | * specific prior written permission.
+            | *
+            | * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+            | * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+            | * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+            | * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+            | * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+            | * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+            | * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+            | * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+            | * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+            | * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+            | */
+            |
+            |""".stripMargin
+
+      mit shouldBe expected
+      headerPattern shouldBe HeaderPattern.cStyleBlockComment
+    }
+
+    "return the BSD 3 Clause license with hash style" in {
+      val (headerPattern, mit) = BSD3Clause("2015", "Heiko Seeberger", "#")
+      val expected =
+        s"""|# Copyright (c) 2015, Heiko Seeberger
+            |# All rights reserved.
+            |#
+            |# Redistribution and use in source and binary forms, with or without modification,
+            |# are permitted provided that the following conditions are met:
+            |#
+            |# 1. Redistributions of source code must retain the above copyright notice, this
+            |# list of conditions and the following disclaimer.
+            |#
+            |# 2. Redistributions in binary form must reproduce the above copyright notice,
+            |# this list of conditions and the following disclaimer in the documentation and/or
+            |# other materials provided with the distribution.
+            |#
+            |# 3. Neither the name of the copyright holder nor the names of its contributors
+            |# may be used to endorse or promote products derived from this software without
+            |# specific prior written permission.
+            |#
+            |# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+            |# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+            |# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+            |# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+            |# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+            |# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+            |# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+            |# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+            |# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+            |# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+            |
+            |""".stripMargin
+
+      mit shouldBe expected
+      headerPattern shouldBe HeaderPattern.hashLineComment
+    }
+
+    "fail when unknown comment style prefix provided" in {
+      intercept[IllegalArgumentException] { BSD3Clause("2015", "Heiko Seeberger", "???") }
+    }
+  }
+}


### PR DESCRIPTION
Not sure if @fommil was kidding in #38, but here is a PR to add BSD 2 Clause and 3 Clause license. If we really want to add more popular licenses, I'd suggest adding GPL, LGPL and Eclipse License. That should cover most projects out there.