### PR TITLE
Implement C++ comment style for built-in Licenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ headers := Map(
 )
 ```
 
+The built-in licenses support three comment styles:
+- C style block comments (default)
+- C++ style line comments (commentStyle = "//")
+- Hash line comments (commentStyle = "#")
+
 Notice that for the header pattern you have to provide a `Regex` which extracts the header and the body for a given file, i.e. one with two capturing groups. `HeaderPattern` defines three widely used patterns:
 - `cStyleBlockComment`, e.g. for Scala and Java
 - `cppStyleLineComment`, e.g. for C++ and Protobuf

--- a/src/main/scala/de/heikoseeberger/sbtheader/license/CommentBlock.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/license/CommentBlock.scala
@@ -36,5 +36,6 @@ object CommentBlock {
 
   val cStyle = new CommentBlock("/*", " *", " */" + System.lineSeparator())
   val hashLines = new CommentBlock("", "#", "")
+  val cppStyle = new CommentBlock("", "//", "")
 
 }

--- a/src/main/scala/de/heikoseeberger/sbtheader/license/License.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/license/License.scala
@@ -26,6 +26,7 @@ trait License {
     commentStyle match {
       case "*" => (cStyleBlockComment, CommentBlock.cStyle(text))
       case "#" => (hashLineComment, CommentBlock.hashLines(text))
+      case "//" => (cppStyleLineComment, CommentBlock.cppStyle(text))
       case _ =>
         throw new IllegalArgumentException(s"Comment style '$commentStyle' not supported")
     }

--- a/src/test/scala/de/heikoseeberger/sbtheader/license/Apache2_0Spec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/license/Apache2_0Spec.scala
@@ -71,6 +71,29 @@ class Apache2_0Spec extends WordSpec with Matchers {
       headerPattern shouldBe HeaderPattern.hashLineComment
     }
 
+    "return the Apache 2.0 license with C++ style" in {
+      val (headerPattern, apache2_0) = Apache2_0("2015", "Heiko Seeberger", "//")
+      val expected =
+        """|// Copyright 2015 Heiko Seeberger
+           |//
+           |// Licensed under the Apache License, Version 2.0 (the "License");
+           |// you may not use this file except in compliance with the License.
+           |// You may obtain a copy of the License at
+           |//
+           |//     http://www.apache.org/licenses/LICENSE-2.0
+           |//
+           |// Unless required by applicable law or agreed to in writing, software
+           |// distributed under the License is distributed on an "AS IS" BASIS,
+           |// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+           |// See the License for the specific language governing permissions and
+           |// limitations under the License.
+           |
+           |""".stripMargin
+
+      apache2_0 shouldBe expected
+      headerPattern shouldBe HeaderPattern.cppStyleLineComment
+    }
+
     "fail when unknown comment style prefix provided" in {
       intercept[IllegalArgumentException] { Apache2_0("2015", "Heiko Seeberger", "???") }
     }

--- a/src/test/scala/de/heikoseeberger/sbtheader/license/BSD2ClauseSpec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/license/BSD2ClauseSpec.scala
@@ -91,6 +91,39 @@ class BSD2ClauseSpec extends WordSpec with Matchers {
       headerPattern shouldBe HeaderPattern.hashLineComment
     }
 
+    "return the BSD 2 Clause license with C++ style" in {
+      val (headerPattern, mit) = BSD2Clause("2015", "Heiko Seeberger", "//")
+      val expected =
+        s"""|// Copyright (c) 2015, Heiko Seeberger
+            |// All rights reserved.
+            |//
+            |// Redistribution and use in source and binary forms, with or without modification,
+            |// are permitted provided that the following conditions are met:
+            |//
+            |// 1. Redistributions of source code must retain the above copyright notice, this
+            |//    list of conditions and the following disclaimer.
+            |//
+            |// 2. Redistributions in binary form must reproduce the above copyright notice,
+            |//    this list of conditions and the following disclaimer in the documentation
+            |//    and/or other materials provided with the distribution.
+            |//
+            |// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+            |// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+            |// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+            |// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+            |// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+            |// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+            |// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+            |// ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+            |// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+            |// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+            |
+            |""".stripMargin
+
+      mit shouldBe expected
+      headerPattern shouldBe HeaderPattern.cppStyleLineComment
+    }
+
     "fail when unknown comment style prefix provided" in {
       intercept[IllegalArgumentException] { BSD2Clause("2015", "Heiko Seeberger", "???") }
     }

--- a/src/test/scala/de/heikoseeberger/sbtheader/license/BSD2ClauseSpec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/license/BSD2ClauseSpec.scala
@@ -24,7 +24,7 @@ class BSD2ClauseSpec extends WordSpec with Matchers {
   "apply" should {
 
     "return the BSD 2 Clause license with the given copyright year and owner" in {
-      val (headerPattern, mit) = BSD2Clause("2015", "Heiko Seeberger")
+      val (headerPattern, bsd2) = BSD2Clause("2015", "Heiko Seeberger")
       val expected =
         s"""|/*
             | * Copyright (c) 2015, Heiko Seeberger
@@ -54,12 +54,12 @@ class BSD2ClauseSpec extends WordSpec with Matchers {
             |
             |""".stripMargin
 
-      mit shouldBe expected
+      bsd2 shouldBe expected
       headerPattern shouldBe HeaderPattern.cStyleBlockComment
     }
 
     "return the BSD 2 Clause license with hash style" in {
-      val (headerPattern, mit) = BSD2Clause("2015", "Heiko Seeberger", "#")
+      val (headerPattern, bsd2) = BSD2Clause("2015", "Heiko Seeberger", "#")
       val expected =
         s"""|# Copyright (c) 2015, Heiko Seeberger
             |# All rights reserved.
@@ -87,12 +87,12 @@ class BSD2ClauseSpec extends WordSpec with Matchers {
             |
             |""".stripMargin
 
-      mit shouldBe expected
+      bsd2 shouldBe expected
       headerPattern shouldBe HeaderPattern.hashLineComment
     }
 
     "return the BSD 2 Clause license with C++ style" in {
-      val (headerPattern, mit) = BSD2Clause("2015", "Heiko Seeberger", "//")
+      val (headerPattern, bsd2) = BSD2Clause("2015", "Heiko Seeberger", "//")
       val expected =
         s"""|// Copyright (c) 2015, Heiko Seeberger
             |// All rights reserved.
@@ -120,7 +120,7 @@ class BSD2ClauseSpec extends WordSpec with Matchers {
             |
             |""".stripMargin
 
-      mit shouldBe expected
+      bsd2 shouldBe expected
       headerPattern shouldBe HeaderPattern.cppStyleLineComment
     }
 

--- a/src/test/scala/de/heikoseeberger/sbtheader/license/BSD3ClauseSpec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/license/BSD3ClauseSpec.scala
@@ -99,6 +99,43 @@ class BSD3ClauseSpec extends WordSpec with Matchers {
       headerPattern shouldBe HeaderPattern.hashLineComment
     }
 
+    "return the BSD 3 Clause license with C++ style" in {
+      val (headerPattern, mit) = BSD3Clause("2015", "Heiko Seeberger", "//")
+      val expected =
+        s"""|// Copyright (c) 2015, Heiko Seeberger
+            |// All rights reserved.
+            |//
+            |// Redistribution and use in source and binary forms, with or without modification,
+            |// are permitted provided that the following conditions are met:
+            |//
+            |// 1. Redistributions of source code must retain the above copyright notice, this
+            |//    list of conditions and the following disclaimer.
+            |//
+            |// 2. Redistributions in binary form must reproduce the above copyright notice,
+            |//    this list of conditions and the following disclaimer in the documentation
+            |//    and/or other materials provided with the distribution.
+            |//
+            |// 3. Neither the name of the copyright holder nor the names of its contributors
+            |//    may be used to endorse or promote products derived from this software without
+            |//    specific prior written permission.
+            |//
+            |// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+            |// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+            |// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+            |// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+            |// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+            |// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+            |// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+            |// ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+            |// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+            |// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+            |
+            |""".stripMargin
+
+      mit shouldBe expected
+      headerPattern shouldBe HeaderPattern.cppStyleLineComment
+    }
+
     "fail when unknown comment style prefix provided" in {
       intercept[IllegalArgumentException] { BSD3Clause("2015", "Heiko Seeberger", "???") }
     }

--- a/src/test/scala/de/heikoseeberger/sbtheader/license/BSD3ClauseSpec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/license/BSD3ClauseSpec.scala
@@ -24,7 +24,7 @@ class BSD3ClauseSpec extends WordSpec with Matchers {
   "apply" should {
 
     "return the BSD 3 Clause license with the given copyright year and owner" in {
-      val (headerPattern, mit) = BSD3Clause("2015", "Heiko Seeberger")
+      val (headerPattern, bsd3) = BSD3Clause("2015", "Heiko Seeberger")
       val expected =
         s"""|/*
             | * Copyright (c) 2015, Heiko Seeberger
@@ -58,12 +58,12 @@ class BSD3ClauseSpec extends WordSpec with Matchers {
             |
             |""".stripMargin
 
-      mit shouldBe expected
+      bsd3 shouldBe expected
       headerPattern shouldBe HeaderPattern.cStyleBlockComment
     }
 
     "return the BSD 3 Clause license with hash style" in {
-      val (headerPattern, mit) = BSD3Clause("2015", "Heiko Seeberger", "#")
+      val (headerPattern, bsd3) = BSD3Clause("2015", "Heiko Seeberger", "#")
       val expected =
         s"""|# Copyright (c) 2015, Heiko Seeberger
             |# All rights reserved.
@@ -95,12 +95,12 @@ class BSD3ClauseSpec extends WordSpec with Matchers {
             |
             |""".stripMargin
 
-      mit shouldBe expected
+      bsd3 shouldBe expected
       headerPattern shouldBe HeaderPattern.hashLineComment
     }
 
     "return the BSD 3 Clause license with C++ style" in {
-      val (headerPattern, mit) = BSD3Clause("2015", "Heiko Seeberger", "//")
+      val (headerPattern, bsd3) = BSD3Clause("2015", "Heiko Seeberger", "//")
       val expected =
         s"""|// Copyright (c) 2015, Heiko Seeberger
             |// All rights reserved.
@@ -132,7 +132,7 @@ class BSD3ClauseSpec extends WordSpec with Matchers {
             |
             |""".stripMargin
 
-      mit shouldBe expected
+      bsd3 shouldBe expected
       headerPattern shouldBe HeaderPattern.cppStyleLineComment
     }
 

--- a/src/test/scala/de/heikoseeberger/sbtheader/license/GPLv3Spec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/license/GPLv3Spec.scala
@@ -73,6 +73,30 @@ class GPLv3Spec extends WordSpec with Matchers {
       headerPattern shouldBe HeaderPattern.hashLineComment
     }
 
+    "return the GPLv3 license with C++ style" in {
+      val (headerPattern, gplv3) = GPLv3("2015", "Heiko Seeberger", "//")
+      val expected =
+        """|// Copyright (C) 2015  Heiko Seeberger
+           |//
+           |// This program is free software: you can redistribute it and/or modify
+           |// it under the terms of the GNU General Public License as published by
+           |// the Free Software Foundation, either version 3 of the License, or
+           |// (at your option) any later version.
+           |//
+           |// This program is distributed in the hope that it will be useful,
+           |// but WITHOUT ANY WARRANTY; without even the implied warranty of
+           |// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+           |// GNU General Public License for more details.
+           |//
+           |// You should have received a copy of the GNU General Public License
+           |// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+           |
+           |""".stripMargin
+
+      gplv3 shouldBe expected
+      headerPattern shouldBe HeaderPattern.cppStyleLineComment
+    }
+
     "fail when unknown comment style prefix provided" in {
       intercept[IllegalArgumentException] { GPLv3("2015", "Heiko Seeberger", "???") }
     }

--- a/src/test/scala/de/heikoseeberger/sbtheader/license/LGPLv3Spec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/license/LGPLv3Spec.scala
@@ -73,6 +73,30 @@ class LGPLv3Spec extends WordSpec with Matchers {
       headerPattern shouldBe HeaderPattern.hashLineComment
     }
 
+    "return the LGPLv3 license with C++ style" in {
+      val (headerPattern, lgplv3) = LGPLv3("2015", "Heiko Seeberger", "//")
+      val expected =
+        """|// Copyright (C) 2015  Heiko Seeberger
+           |//
+           |// This program is free software: you can redistribute it and/or modify
+           |// it under the terms of the GNU Lesser General Public License as published
+           |// by the Free Software Foundation, either version 3 of the License, or
+           |// (at your option) any later version.
+           |//
+           |// This program is distributed in the hope that it will be useful,
+           |// but WITHOUT ANY WARRANTY; without even the implied warranty of
+           |// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+           |// GNU Lesser General Public License for more details.
+           |//
+           |// You should have received a copy of the GNU General Lesser Public License
+           |// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+           |
+           |""".stripMargin
+
+      lgplv3 shouldBe expected
+      headerPattern shouldBe HeaderPattern.cppStyleLineComment
+    }
+
     "fail when unknown comment style prefix provided" in {
       intercept[IllegalArgumentException] { LGPLv3("2015", "Heiko Seeberger", "???") }
     }

--- a/src/test/scala/de/heikoseeberger/sbtheader/license/MITSpec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/license/MITSpec.scala
@@ -81,6 +81,34 @@ class MITSpec extends WordSpec with Matchers {
       headerPattern shouldBe HeaderPattern.hashLineComment
     }
 
+    "return the MIT license with C++ style" in {
+      val (headerPattern, mit) = MIT("2015", "Heiko Seeberger", "//")
+      val expected =
+        s"""|// Copyright (c) 2015 Heiko Seeberger
+            |//
+            |// Permission is hereby granted, free of charge, to any person obtaining a copy of
+            |// this software and associated documentation files (the "Software"), to deal in
+            |// the Software without restriction, including without limitation the rights to
+            |// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+            |// the Software, and to permit persons to whom the Software is furnished to do so,
+            |// subject to the following conditions:
+            |//
+            |// The above copyright notice and this permission notice shall be included in all
+            |// copies or substantial portions of the Software.
+            |//
+            |// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+            |// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+            |// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+            |// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+            |// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+            |// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+            |
+            |""".stripMargin
+
+      mit shouldBe expected
+      headerPattern shouldBe HeaderPattern.cppStyleLineComment
+    }
+
     "fail when unknown comment style prefix provided" in {
       intercept[IllegalArgumentException] { MIT("2015", "Heiko Seeberger", "???") }
     }


### PR DESCRIPTION
- Changed implementation of License trait to be able to handle C++ style line comments
- Document built-in comment styles

Note: This PR includes one unrelated change: I've corrected wrong local variable names in the BSD specs.