### PR TITLE
Add comment style auto detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,15 @@ The built-in licenses support three comment styles:
 - C++ style line comments (commentStyle = "//")
 - Hash line comments (commentStyle = "#")
 
+The CommentStyleMapping object in [HeaderPlugin](https://github.com/sbt/sbt-header/blob/master/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala) provides default mappings for common file types, so that they don't have to be configured manually:
+
+``` scala
+import de.heikoseeberger.sbtheader.license.Apache2_0
+import de.heikoseeberger.sbtheader.CommentStyleMapping._
+
+headers := createFrom(Apache2_0, "2015", "Heiko Seeberger")
+```
+
 Notice that for the header pattern you have to provide a `Regex` which extracts the header and the body for a given file, i.e. one with two capturing groups. `HeaderPattern` defines three widely used patterns:
 - `cStyleBlockComment`, e.g. for Scala and Java
 - `cppStyleLineComment`, e.g. for C++ and Protobuf

--- a/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala
@@ -36,6 +36,22 @@ object HeaderPattern {
     new Regex(raw"""(?s)((?:$start[^\n\r]*(?:\n|\r|\r\n))*(?:#[^\n\r]*(?:(?:\n){2,}|(?:\r){2,}|(?:\r\n){2,})+))(.*)""")
 }
 
+object CommentStyleMapping {
+  import de.heikoseeberger.sbtheader.license._
+
+  val JavaBlockComments = "java" -> "*"
+  val ScalaBlockComments = "scala" -> "*"
+
+  def createFrom(
+    license: License, 
+    yyyy: String, 
+    copyrightOwner: String, 
+    mappings: Seq[(String, String)] = Seq(JavaBlockComments, ScalaBlockComments)
+  ): Map[String, (Regex, String)] = {
+    mappings.map { mapping => mapping._1 -> license(yyyy, copyrightOwner, mapping._2) }.toMap
+  }
+}
+
 object HeaderKey {
   val headers = settingKey[Map[String, (Regex, String)]]("Header pattern and text by extension; empty by default")
   val createHeaders = taskKey[Iterable[File]]("Create/update headers")

--- a/src/test/scala/de/heikoseeberger/sbtheader/CommentStyleMappingSpec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/CommentStyleMappingSpec.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.heikoseeberger.sbtheader
+
+import de.heikoseeberger.sbtheader.license.Apache2_0
+import org.scalatest.{ Matchers, WordSpec }
+import de.heikoseeberger.sbtheader.HeaderPattern._
+
+class CommentStyleMappingSpec extends WordSpec with Matchers {
+
+  "Default CommentStyleMapping" should {
+    val mapping = CommentStyleMapping.createFrom(Apache2_0, "2016", "John Doe")
+
+    "contain a mapping from java files to C style block comments" in {
+      mapping should contain key "java"
+      mapping("java")._1 shouldBe cStyleBlockComment
+    }
+
+    "contain a mapping from scala files to C style block comments" in {
+      mapping should contain key "scala"
+      mapping("scala")._1 shouldBe cStyleBlockComment
+    }
+  }
+
+  "Custom CommentStyleMapping" should {
+    val mapping = CommentStyleMapping.createFrom(
+      Apache2_0,
+      "2016",
+      "John Doe",
+      Seq("conf" -> "#", "properties" -> "#", "yml" -> "#")
+    )
+
+    "map conf files to hash line comments" in {
+      mapping should contain key "conf"
+      mapping("conf")._1 shouldBe hashLineComment
+    }
+
+    "map properties files to hash line comments" in {
+      mapping should contain key "properties"
+      mapping("properties")._1 shouldBe hashLineComment
+    }
+
+    "map yml files to hash line comments" in {
+      mapping should contain key "yml"
+      mapping("yml")._1 shouldBe hashLineComment
+    }
+  }
+}


### PR DESCRIPTION
As discussed in #44, it would be useful to have a convenience method that creates a mapping from file extension to License for common file extensions.

This PR introduces the CommentStyleMapping object with a single method: `createFrom(License, String, String)`. Currently the following file types are mapped by this method: scala, java, groovy, h, conf, properties, yml, sh.

After applying this PR, the following configuration:

```scala
import de.heikoseeberger.sbtheader.license.Apache2_0

headers := Map(
  "scala" -> Apache2_0("2015", "Heiko Seeberger")
  "conf" -> Apache2_0("2015", "Heiko Seeberger", "#")
)
```

can be changed to:

```scala
import de.heikoseeberger.sbtheader.license.Apache2_0
import de.heikoseeberger.sbtheader.CommentStyleMapping._

headers := createFrom(Apache2_0, "2015", "Heiko Seeberger")
```