### PR TITLE
Allow for /** C-style comments

### DIFF
--- a/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala
@@ -26,7 +26,7 @@ import scala.util.matching.Regex
 import java.io.FileInputStream
 
 object HeaderPattern {
-  val cStyleBlockComment = commentBetween("""/\**""", "*", """\*/""")
+  val cStyleBlockComment = commentBetween("""/\*+""", "*", """\*/""")
   val cppStyleLineComment = commentStartingWith("//")
   val hashLineComment = commentStartingWith("#")
 

--- a/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala
@@ -26,7 +26,7 @@ import scala.util.matching.Regex
 import java.io.FileInputStream
 
 object HeaderPattern {
-  val cStyleBlockComment = commentBetween("""/\*""", "*", """\*/""")
+  val cStyleBlockComment = commentBetween("""/\**""", "*", """\*/""")
   val cppStyleLineComment = commentStartingWith("//")
   val hashLineComment = commentStartingWith("#")
 
@@ -43,9 +43,9 @@ object CommentStyleMapping {
   val ScalaBlockComments = "scala" -> "*"
 
   def createFrom(
-    license: License, 
-    yyyy: String, 
-    copyrightOwner: String, 
+    license: License,
+    yyyy: String,
+    copyrightOwner: String,
     mappings: Seq[(String, String)] = Seq(JavaBlockComments, ScalaBlockComments)
   ): Map[String, (Regex, String)] = {
     mappings.map { mapping => mapping._1 -> license(yyyy, copyrightOwner, mapping._2) }.toMap

--- a/src/main/scala/de/heikoseeberger/sbtheader/license/CommentBlock.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/license/CommentBlock.scala
@@ -27,8 +27,8 @@ class CommentBlock(blockPrefix: String, linePrefix: String, blockSuffix: String)
   }
 
   private val prependWithLinePrefix: String => String = {
-    case ""    => linePrefix
-    case line  => linePrefix + " " + line
+    case ""   => linePrefix
+    case line => linePrefix + " " + line
   }
 }
 

--- a/src/main/scala/de/heikoseeberger/sbtheader/license/License.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/license/License.scala
@@ -24,8 +24,8 @@ trait License {
   def apply(yyyy: String, copyrightOwner: String, commentStyle: String = "*"): (Regex, String) = {
     val text = createLicenseText(yyyy, copyrightOwner)
     commentStyle match {
-      case "*" => (cStyleBlockComment, CommentBlock.cStyle(text))
-      case "#" => (hashLineComment, CommentBlock.hashLines(text))
+      case "*"  => (cStyleBlockComment, CommentBlock.cStyle(text))
+      case "#"  => (hashLineComment, CommentBlock.hashLines(text))
       case "//" => (cppStyleLineComment, CommentBlock.cppStyle(text))
       case _ =>
         throw new IllegalArgumentException(s"Comment style '$commentStyle' not supported")

--- a/src/test/scala/de/heikoseeberger/sbtheader/HeaderPluginSpec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/HeaderPluginSpec.scala
@@ -72,6 +72,22 @@ class HeaderPluginSpec extends WordSpec with Matchers {
                     |""".stripMargin
       HeaderPattern.cStyleBlockComment.unapplySeq(header + body) shouldBe Some(List(header, body))
     }
+
+    "match a left indented header with a trailing new line followed by a body with a ScalaDoc comment" in {
+      val header = """|/**
+                      | * comment/1
+                      | * comment/2
+                      | */
+                      |""".stripMargin
+      val body = """|/**
+                    |  * ScalaDoc for Foo
+                    |  */
+                    |class Foo {
+                    |  val bar = "bar"
+                    |}
+                    |""".stripMargin
+      HeaderPattern.cStyleBlockComment.unapplySeq(header + body) shouldBe Some(List(header, body))
+    }
   }
 
   "HeaderPattern.hashLineComment" should {

--- a/src/test/scala/de/heikoseeberger/sbtheader/license/BSD3ClauseSpec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/license/BSD3ClauseSpec.scala
@@ -17,7 +17,7 @@
 package de.heikoseeberger.sbtheader.license
 
 import de.heikoseeberger.sbtheader.HeaderPattern
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.{ Matchers, WordSpec }
 
 class BSD3ClauseSpec extends WordSpec with Matchers {
 

--- a/src/test/scala/de/heikoseeberger/sbtheader/license/GPLv3Spec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/license/GPLv3Spec.scala
@@ -17,7 +17,7 @@
 package de.heikoseeberger.sbtheader.license
 
 import de.heikoseeberger.sbtheader.HeaderPattern
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.{ Matchers, WordSpec }
 
 class GPLv3Spec extends WordSpec with Matchers {
 

--- a/src/test/scala/de/heikoseeberger/sbtheader/license/LGPLv3Spec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/license/LGPLv3Spec.scala
@@ -17,7 +17,7 @@
 package de.heikoseeberger.sbtheader.license
 
 import de.heikoseeberger.sbtheader.HeaderPattern
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.{ Matchers, WordSpec }
 
 class LGPLv3Spec extends WordSpec with Matchers {
 


### PR DESCRIPTION
- This change provides the ability to use comments that look like:
   /**
    * License is here
    */

- Other changes were made by scalariform