### PR TITLE
Fix #30: ability to ignore some files

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,20 @@ headers := Map(
 )
 ```
 
+To exclude some files, use the `excludes` setting. It accepts glob file name patterns relative to the project root:
+
+``` scala
+import de.heikoseeberger.sbtheader.HeaderPattern
+
+headers := Map(
+  "scala" -> Apache2_0("2015", "Heiko Seeberger")
+)
+
+excludes := Seq(
+  "src/generated/**",
+)
+```
+
 The most common licenses have been pre-canned in [License](https://github.com/sbt/sbt-header/blob/master/src/main/scala/de/heikoseeberger/sbtheader/license/License.scala):
 - [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
 - [MIT License](https://opensource.org/licenses/MIT)

--- a/src/main/scala/de/heikoseeberger/sbtheader/FileFilter.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/FileFilter.scala
@@ -19,11 +19,7 @@ package de.heikoseeberger.sbtheader
 import java.io.File
 import java.nio.file.FileSystems
 
-object FileFilter {
-  def apply(excludes: Seq[String]): FileFilter = new FileFilter(excludes)
-}
-
-class FileFilter(val excludes: Seq[String]) {
+case class FileFilter(excludes: Seq[String]) {
 
   // adding **/ to the start of the pattern so that users define their ignores relative to the project root
   private val matchers = excludes.map(p => FileSystems.getDefault.getPathMatcher(s"glob:**/$p"))

--- a/src/main/scala/de/heikoseeberger/sbtheader/FileFilter.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/FileFilter.scala
@@ -21,10 +21,10 @@ import java.nio.file.FileSystems
 
 case class FileFilter(excludes: Seq[String]) {
 
-  // adding **/ to the start of the pattern so that users define their ignores relative to the project root
-  private val matchers = excludes.map(p => FileSystems.getDefault.getPathMatcher(s"glob:**/$p"))
-
   def filter(files: Seq[File]): Seq[File] = {
+    // adding **/ to the start of the pattern so that users define their ignores relative to the project root
+    val matchers = excludes.map(p => FileSystems.getDefault.getPathMatcher(s"glob:**/$p"))
+
     files.filterNot(f => matchers.exists(_.matches(f.toPath)))
   }
 }

--- a/src/main/scala/de/heikoseeberger/sbtheader/FileFilter.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/FileFilter.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.heikoseeberger.sbtheader
+
+import java.io.File
+import java.nio.file.FileSystems
+
+object FileFilter {
+  def apply(excludes: Seq[String]): FileFilter = new FileFilter(excludes)
+}
+
+class FileFilter(val excludes: Seq[String]) {
+
+  // adding **/ to the start of the pattern so that users define their ignores relative to the project root
+  private val matchers = excludes.map(p => FileSystems.getDefault.getPathMatcher(s"glob:**/$p"))
+
+  def filter(files: Seq[File]): Seq[File] = {
+    files.filterNot(f => matchers.exists(_.matches(f.toPath)))
+  }
+}

--- a/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala
@@ -54,7 +54,8 @@ object CommentStyleMapping {
 
 object HeaderKey {
   val headers = settingKey[Map[String, (Regex, String)]]("Header pattern and text by extension; empty by default")
-  val excludes = settingKey[Seq[String]]("File patterns for files to be excluded; empty by default")
+  /* explicitly use the default (mutable) Seq here */
+  val excludes = settingKey[scala.collection.Seq[String]]("File patterns for files to be excluded; empty by default")
   val createHeaders = taskKey[Iterable[File]]("Create/update headers")
 }
 
@@ -97,7 +98,7 @@ object HeaderPlugin extends AutoPlugin {
     unmanagedSources in createHeaders := unmanagedSources.value,
     unmanagedResources in createHeaders := unmanagedResources.value,
     createHeaders := createHeadersTask(
-      FileFilter(excludes.value).filter(
+      FileFilter(Seq(excludes.value: _*)).filter(
         (unmanagedSources in createHeaders).value.toList ++ (unmanagedResources in createHeaders).value.toList
       ),
       headers.value,

--- a/src/sbt-test/sbt-header/excludes/project/test.sbt
+++ b/src/sbt-test/sbt-header/excludes/project/test.sbt
@@ -1,0 +1,5 @@
+val pluginVersion = sys.props
+  .get("plugin.version")
+  .getOrElse(sys.error("Sys prop plugin.version must be defined!"))
+
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % pluginVersion)

--- a/src/sbt-test/sbt-header/excludes/src/main/resources/Excluded.scala_expected
+++ b/src/sbt-test/sbt-header/excludes/src/main/resources/Excluded.scala_expected
@@ -1,0 +1,3 @@
+package de.heikoseeberger.sbtheader.test;
+
+class Excluded

--- a/src/sbt-test/sbt-header/excludes/src/main/resources/Included.scala_expected
+++ b/src/sbt-test/sbt-header/excludes/src/main/resources/Included.scala_expected
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.heikoseeberger.sbtheader.test;
+
+class Included

--- a/src/sbt-test/sbt-header/excludes/src/main/scala/Excluded.scala
+++ b/src/sbt-test/sbt-header/excludes/src/main/scala/Excluded.scala
@@ -1,0 +1,3 @@
+package de.heikoseeberger.sbtheader.test;
+
+class Excluded

--- a/src/sbt-test/sbt-header/excludes/src/main/scala/Included.scala
+++ b/src/sbt-test/sbt-header/excludes/src/main/scala/Included.scala
@@ -1,0 +1,3 @@
+package de.heikoseeberger.sbtheader.test;
+
+class Included

--- a/src/sbt-test/sbt-header/excludes/src/main/scala/de/heikoseeberger/allexcluded/Excluded.scala
+++ b/src/sbt-test/sbt-header/excludes/src/main/scala/de/heikoseeberger/allexcluded/Excluded.scala
@@ -1,0 +1,3 @@
+package de.heikoseeberger.sbtheader.test;
+
+class Excluded

--- a/src/sbt-test/sbt-header/excludes/src/main/scala/de/heikoseeberger/allincluded/Included.scala
+++ b/src/sbt-test/sbt-header/excludes/src/main/scala/de/heikoseeberger/allincluded/Included.scala
@@ -1,0 +1,3 @@
+package de.heikoseeberger.sbtheader.test;
+
+class Included

--- a/src/sbt-test/sbt-header/excludes/src/main/scala/de/heikoseeberger/mixed/Excluded.scala
+++ b/src/sbt-test/sbt-header/excludes/src/main/scala/de/heikoseeberger/mixed/Excluded.scala
@@ -1,0 +1,3 @@
+package de.heikoseeberger.sbtheader.test;
+
+class Excluded

--- a/src/sbt-test/sbt-header/excludes/src/main/scala/de/heikoseeberger/mixed/Included.scala
+++ b/src/sbt-test/sbt-header/excludes/src/main/scala/de/heikoseeberger/mixed/Included.scala
@@ -1,0 +1,3 @@
+package de.heikoseeberger.sbtheader.test;
+
+class Included

--- a/src/sbt-test/sbt-header/excludes/test
+++ b/src/sbt-test/sbt-header/excludes/test
@@ -1,0 +1,3 @@
+# check if headers get created
+> createHeaders
+> checkFileContents

--- a/src/sbt-test/sbt-header/excludes/test.sbt
+++ b/src/sbt-test/sbt-header/excludes/test.sbt
@@ -4,7 +4,7 @@ headers := Map(
   "scala" -> Apache2_0("2015", "Heiko Seeberger")
 )
 
-excludes := scala.collection.immutable.Seq(
+excludes := Seq(
   "src/main/scala/Excluded.scala",
   "src/main/scala/de/heikoseeberger/mixed/Excluded.scala",
   "src/main/scala/de/heikoseeberger/allexcluded/*.scala",

--- a/src/sbt-test/sbt-header/excludes/test.sbt
+++ b/src/sbt-test/sbt-header/excludes/test.sbt
@@ -1,0 +1,48 @@
+import de.heikoseeberger.sbtheader.license.Apache2_0
+
+headers := Map(
+  "scala" -> Apache2_0("2015", "Heiko Seeberger")
+)
+
+excludes := scala.collection.immutable.Seq(
+  "src/main/scala/Excluded.scala",
+  "src/main/scala/de/heikoseeberger/mixed/Excluded.scala",
+  "src/main/scala/de/heikoseeberger/allexcluded/*.scala",
+  "src/main/scala/de/heikoseeberger/allincluded/*.java"
+)
+
+val checkFileContents = taskKey[Unit]("Verify file contents match expected contents")
+checkFileContents := {
+
+  val includeFiles = Seq(
+    (scalaSource.in(Compile).value / "Included.scala").toString,
+    (scalaSource.in(Compile).value / "de/heikoseeberger/allincluded/Included.scala").toString,
+    (scalaSource.in(Compile).value / "de/heikoseeberger/mixed/Included.scala").toString
+  )
+  val excludeFiles = Seq(
+    (scalaSource.in(Compile).value / "Excluded.scala").toString,
+    (scalaSource.in(Compile).value / "de/heikoseeberger/allexcluded/Excluded.scala").toString,
+    (scalaSource.in(Compile).value / "de/heikoseeberger/mixed/Excluded.scala").toString
+  )
+
+  val expectedExcludedFile = (resourceDirectory.in(Compile).value / "Excluded.scala_expected").toString
+  val expectedIncludedFile = (resourceDirectory.in(Compile).value / "Included.scala_expected").toString
+
+  checkFiles(excludeFiles, expectedExcludedFile)
+  checkFiles(includeFiles, expectedIncludedFile)
+
+  def checkFiles(filePaths: Seq[String], expectedPath: String) = {
+    val expected = scala.io.Source.fromFile(expectedPath).mkString
+
+    filePaths.foreach { actualPath =>
+      val actual = scala.io.Source.fromFile(actualPath).mkString
+  
+      if (actual != expected) sys.error(
+        s"""|Actual file contents do not match expected file contents!
+            |  actual:   $actualPath
+            |  expected: $expectedPath
+            |""".stripMargin)
+    }
+  }
+
+}

--- a/src/test/scala/de/heikoseeberger/sbtheader/FileFilterSpec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/FileFilterSpec.scala
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.heikoseeberger.sbtheader
+
+import java.io.File
+
+import org.scalatest.{ Matchers, WordSpec }
+
+class FileFilterSpec extends WordSpec with Matchers {
+
+  val emptyFiles = Seq.empty
+  val scalaFiles = Seq(new File("/project/src/main/scala/SomeFile.scala"), new File("/project/src/main/scala/AnotherFile.scala"))
+  val javaFiles = Seq(new File("/project/src/main/java/SomeFile.java"), new File("/project/src/main/java/AnotherFile.java"))
+  val mixedFiles = scalaFiles ++ javaFiles
+
+  "Empty FileFilter" should {
+
+    val filter = FileFilter(Seq.empty)
+
+    "not filter empty files" in {
+      filter.filter(emptyFiles) shouldBe emptyFiles
+    }
+
+    "not filter files" in {
+      filter.filter(scalaFiles) shouldBe scalaFiles
+    }
+  }
+
+  "FilterFilter filtering scala files" should {
+    val filter = FileFilter(Seq("**/*.scala"))
+
+    "not filter empty files" in {
+      filter.filter(emptyFiles) shouldBe emptyFiles
+    }
+
+    "filter all scala files" in {
+      filter.filter(scalaFiles) shouldBe Seq.empty
+    }
+
+    "not filter java files" in {
+      filter.filter(javaFiles) shouldBe javaFiles
+    }
+
+    "should only filter scala files from mixed files" in {
+      filter.filter(mixedFiles) shouldBe javaFiles
+    }
+  }
+
+  "FilterFilter filtering the scala directory" should {
+    val filter = FileFilter(Seq("**/scala/**"))
+
+    "not filter empty files" in {
+      filter.filter(emptyFiles) shouldBe emptyFiles
+    }
+
+    "filter all scala files" in {
+      filter.filter(scalaFiles) shouldBe Seq.empty
+    }
+
+    "not filter java files" in {
+      filter.filter(javaFiles) shouldBe javaFiles
+    }
+
+    "should only filter scala files from mixed files" in {
+      filter.filter(mixedFiles) shouldBe javaFiles
+    }
+  }
+
+  "FilterFilter filtering a specific scala file" should {
+    val filter = FileFilter(Seq("**/SomeFile.scala"))
+
+    "not filter empty files" in {
+      filter.filter(emptyFiles) shouldBe emptyFiles
+    }
+
+    "filter only filter that file from all scala files" in {
+      filter.filter(scalaFiles) shouldBe Seq(new File("/project/src/main/scala/AnotherFile.scala"))
+    }
+
+    "not filter java files" in {
+      filter.filter(javaFiles) shouldBe javaFiles
+    }
+
+    "should only filter that file form mixed files" in {
+      filter.filter(mixedFiles) shouldBe new File("/project/src/main/scala/AnotherFile.scala") +: javaFiles
+    }
+  }
+}


### PR DESCRIPTION
This is a fix for #30. It introduces a new settings key: `excludes` which is a Seq of strings denoting the file patterns to exclude. Users can specify glob patterns to exclude files form header creation. patterns may be relative to the project root.