### PR TITLE
#57: Task to verify the presence of headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,15 @@ In order to create or update file headers, execute the `createHeaders` task:
 [info]   /Users/heiko/projects/sbt-header/sbt-header-test/test2.scala
 ```
 
+In order to check whether all files have headers, execute the `checkHeaders` task:
+
+```
+> checkHeaders
+[error] (compile:checkHeaders) There are files without headers!
+[error]   /Users/heiko/projects/sbt-header/sbt-header-test/test.scala
+[error]   /Users/heiko/projects/sbt-header/sbt-header-test/test2.scala
+```
+
 ### Automation
 
 If you want to automate header creation/update on compile, enable the `AutomateHeaderPlugin`:

--- a/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala
@@ -19,10 +19,8 @@ package de.heikoseeberger.sbtheader
 import java.io.File
 import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.Files
-
 import sbt._
-import sbt.Keys.{ unmanagedSources, _ }
-
+import sbt.Keys._
 import scala.collection.JavaConversions._
 import scala.util.matching.Regex
 import java.io.FileInputStream

--- a/src/sbt-test/sbt-header/checkHeaders-fails/project/test.sbt
+++ b/src/sbt-test/sbt-header/checkHeaders-fails/project/test.sbt
@@ -1,0 +1,5 @@
+val pluginVersion = sys.props
+  .get("plugin.version")
+  .getOrElse(sys.error("Sys prop plugin.version must be defined!"))
+
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % pluginVersion)

--- a/src/sbt-test/sbt-header/checkHeaders-fails/src/main/scala/HasHeader.scala
+++ b/src/sbt-test/sbt-header/checkHeaders-fails/src/main/scala/HasHeader.scala
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+class HasHeader

--- a/src/sbt-test/sbt-header/checkHeaders-fails/src/main/scala/HasNoHeader.scala
+++ b/src/sbt-test/sbt-header/checkHeaders-fails/src/main/scala/HasNoHeader.scala
@@ -1,0 +1,1 @@
+class HasNoHeader

--- a/src/sbt-test/sbt-header/checkHeaders-fails/test
+++ b/src/sbt-test/sbt-header/checkHeaders-fails/test
@@ -1,0 +1,2 @@
+# check for headers and expect a build failure
+-> checkHeaders

--- a/src/sbt-test/sbt-header/checkHeaders-fails/test.sbt
+++ b/src/sbt-test/sbt-header/checkHeaders-fails/test.sbt
@@ -1,0 +1,5 @@
+import de.heikoseeberger.sbtheader.license.Apache2_0
+
+headers := Map(
+  "scala" -> Apache2_0("2015", "Heiko Seeberger")
+)

--- a/src/sbt-test/sbt-header/checkHeaders/project/test.sbt
+++ b/src/sbt-test/sbt-header/checkHeaders/project/test.sbt
@@ -1,0 +1,5 @@
+val pluginVersion = sys.props
+  .get("plugin.version")
+  .getOrElse(sys.error("Sys prop plugin.version must be defined!"))
+
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % pluginVersion)

--- a/src/sbt-test/sbt-header/checkHeaders/src/main/scala/HasHeader.scala
+++ b/src/sbt-test/sbt-header/checkHeaders/src/main/scala/HasHeader.scala
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+class HasHeader

--- a/src/sbt-test/sbt-header/checkHeaders/test
+++ b/src/sbt-test/sbt-header/checkHeaders/test
@@ -1,0 +1,2 @@
+# check headers and expect no build failure
+> checkHeaders

--- a/src/sbt-test/sbt-header/checkHeaders/test.sbt
+++ b/src/sbt-test/sbt-header/checkHeaders/test.sbt
@@ -1,0 +1,5 @@
+import de.heikoseeberger.sbtheader.license.Apache2_0
+
+headers := Map(
+  "scala" -> Apache2_0("2015", "Heiko Seeberger")
+)


### PR DESCRIPTION
Fix for #57: Add task checkHeaders which will cause the build to fail in case there are files missing a header.