### PR TITLE
#66: Add AppVeyor build definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # sbt-header #
 
 [![Build Status](https://travis-ci.org/sbt/sbt-header.svg?branch=master)](https://travis-ci.org/sbt/sbt-header)
+[![Build status](https://ci.appveyor.com/api/projects/status/bycajw36t0fie2s0/branch/master?svg=true)](https://ci.appveyor.com/project/britter/sbt-header/branch/master)
 [![Download](https://api.bintray.com/packages/hseeberger/sbt-plugins/sbt-header/images/download.svg)](https://bintray.com/hseeberger/sbt-plugins/sbt-header/_latestVersion)
 [![License](http://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
 [![Join the chat at https://gitter.im/sbt/sbt-header](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/sbt/sbt-header?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,13 @@
+install:
+  - cinst sbt -y
+  - cmd: SET PATH=%PATH;"C:\Program Files (x86)\sbt\bin"
+  - cmd: SET JAVA_HOME=C:\Program Files\Java\jdk1.8.0
+  - cmd: SET JAVA_TOOL_OPTIONS=-Dfile.encoding="UTF-8"
+platform:
+  - x86
+  - x64
+build_script:
+  - sbt compile
+test_script:
+  - sbt test
+  - sbt scripted

--- a/src/sbt-test/sbt-header/simple/src/main/resources/HasHeader.scala_expected
+++ b/src/sbt-test/sbt-header/simple/src/main/resources/HasHeader.scala_expected
@@ -16,4 +16,4 @@
 
 package de.heikoseeberger.sbtheader.test;
 
-class Main
+class HasHeader

--- a/src/sbt-test/sbt-header/simple/src/main/resources/HasNoHeader.scala_expected
+++ b/src/sbt-test/sbt-header/simple/src/main/resources/HasNoHeader.scala_expected
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.heikoseeberger.sbtheader.test;
+
+class HasNoHeader

--- a/src/sbt-test/sbt-header/simple/src/main/scala/HasHeader.scala
+++ b/src/sbt-test/sbt-header/simple/src/main/scala/HasHeader.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.heikoseeberger.sbtheader.test;
+
+class HasHeader

--- a/src/sbt-test/sbt-header/simple/src/main/scala/HasNoHeader.scala
+++ b/src/sbt-test/sbt-header/simple/src/main/scala/HasNoHeader.scala
@@ -1,3 +1,3 @@
 package de.heikoseeberger.sbtheader.test;
 
-class Main
+class HasNoHeader

--- a/src/sbt-test/sbt-header/simple/test.sbt
+++ b/src/sbt-test/sbt-header/simple/test.sbt
@@ -6,15 +6,24 @@ headers := Map(
 
 val checkFileContents = taskKey[Unit]("Verify file contents match expected contents")
 checkFileContents := {
-  val actualPath = (scalaSource.in(Compile).value / "Main.scala").toString
-  val expectedPath = (resourceDirectory.in(Compile).value / "Main.scala_expected").toString
+  checkFile("HasHeader.scala")
+  checkFile("HasNoHeader.scala")
 
-  val actual = scala.io.Source.fromFile(actualPath).mkString
-  val expected = scala.io.Source.fromFile(expectedPath).mkString
+  def checkFile(name: String) = {
+    val actualPath = (scalaSource.in(Compile).value / name).toString
+    val expectedPath = (resourceDirectory.in(Compile).value / s"${name}_expected").toString
 
-  if (actual != expected) sys.error(
-    s"""|Actual file contents do not match expected file contents!
-        |  actual:   $actualPath
-        |  expected: $expectedPath
-        |""".stripMargin)
+    val actual = scala.io.Source.fromFile(actualPath).mkString
+    val expected = scala.io.Source.fromFile(expectedPath).mkString
+
+    if (actual != expected) sys.error(
+      s"""|Actual file contents do not match expected file contents!
+          |  actual: $actualPath
+          |$actual
+          |
+          |  expected: $expectedPath
+          |$expected
+          |""".stripMargin)
+
+  }
 }


### PR DESCRIPTION
Fix for #66 CI Build on Windows. Add an AppVeyor build definition. See https://ci.appveyor.com/project/britter/sbt-header how this will look like. To set this up, someone with access to the sbt organization has to login into AppVeyor and activate it for this repository. Further more the link in README.md has to be adjusted (you can copy paste it from the settings panel in AppVeyor).