### PR TITLE
Try to fix AppVeyor build.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,5 @@
+init:
+  - git config --global core.autocrlf true
 install:
   - cinst sbt -y
   - cmd: SET PATH=%PATH;"C:\Program Files (x86)\sbt\bin"


### PR DESCRIPTION
The default core.autocrlf for AppVeyor builds is input, see https://www.appveyor.com/docs/appveyor-yml/
GitHub documentation says one should use core.autocrlf = true on windows
machines, see https://help.github.com/articles/dealing-with-line-endings/#platform-windows

This could be a fix for #68. Waiting for the AppVeyor build to complete.