### PR TITLE
WIP: Introduce CommentStyle AST to make match in License exhausive (#78)

### DIFF
--- a/src/main/scala/de/heikoseeberger/sbtheader/CommentStyle.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/CommentStyle.scala
@@ -16,17 +16,38 @@
 
 package de.heikoseeberger.sbtheader
 
+import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.HeaderPattern._
+
+import scala.util.matching.Regex
+
 /**
   * Representation of the different comment styles supported by this plugin.
   */
-sealed trait CommentStyle
+sealed trait CommentStyle {
+  def apply(licenseText: String): (Regex, String)
+}
 
-case object CStyleBlockComment extends CommentStyle
+case object CStyleBlockComment extends CommentStyle {
+  override def apply(licenseText: String): (Regex, String) =
+    (cStyleBlockComment, CommentBlock.cStyle(licenseText))
+}
 
-case object CppStyleLineComment extends CommentStyle
+case object CppStyleLineComment extends CommentStyle {
+  override def apply(licenseText: String): (Regex, String) =
+    (cppStyleLineComment, CommentBlock.cppStyle(licenseText))
+}
 
-case object HashLineComment extends CommentStyle
+case object HashLineComment extends CommentStyle {
+  override def apply(licenseText: String): (Regex, String) =
+    (hashLineComment, CommentBlock.hashLines(licenseText))
+}
 
-case object TwirlStyleComment extends CommentStyle
+case object TwirlStyleComment extends CommentStyle {
+  override def apply(licenseText: String): (Regex, String) =
+    (twirlStyleComment, CommentBlock.twirlStyle(licenseText))
+}
 
-case object TwirlStyleBlockComment extends CommentStyle
+case object TwirlStyleBlockComment extends CommentStyle {
+  override def apply(licenseText: String): (Regex, String) =
+    (twirlBlockComment, CommentBlock.twirlBlock(licenseText))
+}

--- a/src/main/scala/de/heikoseeberger/sbtheader/CommentStyle.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/CommentStyle.scala
@@ -27,27 +27,31 @@ sealed trait CommentStyle {
   def apply(licenseText: String): (Regex, String)
 }
 
-case object CStyleBlockComment extends CommentStyle {
-  override def apply(licenseText: String): (Regex, String) =
-    (cStyleBlockComment, CommentBlock.cStyle(licenseText))
-}
+object CommentStyle {
 
-case object CppStyleLineComment extends CommentStyle {
-  override def apply(licenseText: String): (Regex, String) =
-    (cppStyleLineComment, CommentBlock.cppStyle(licenseText))
-}
+  final case object CStyleBlockComment extends CommentStyle {
+    override def apply(licenseText: String): (Regex, String) =
+      (cStyleBlockComment, CommentBlock.cStyle(licenseText))
+  }
 
-case object HashLineComment extends CommentStyle {
-  override def apply(licenseText: String): (Regex, String) =
-    (hashLineComment, CommentBlock.hashLines(licenseText))
-}
+  case object CppStyleLineComment extends CommentStyle {
+    override def apply(licenseText: String): (Regex, String) =
+      (cppStyleLineComment, CommentBlock.cppStyle(licenseText))
+  }
 
-case object TwirlStyleComment extends CommentStyle {
-  override def apply(licenseText: String): (Regex, String) =
-    (twirlStyleComment, CommentBlock.twirlStyle(licenseText))
-}
+  case object HashLineComment extends CommentStyle {
+    override def apply(licenseText: String): (Regex, String) =
+      (hashLineComment, CommentBlock.hashLines(licenseText))
+  }
 
-case object TwirlStyleBlockComment extends CommentStyle {
-  override def apply(licenseText: String): (Regex, String) =
-    (twirlBlockComment, CommentBlock.twirlBlock(licenseText))
+  case object TwirlStyleComment extends CommentStyle {
+    override def apply(licenseText: String): (Regex, String) =
+      (twirlStyleComment, CommentBlock.twirlStyle(licenseText))
+  }
+
+  case object TwirlStyleBlockComment extends CommentStyle {
+    override def apply(licenseText: String): (Regex, String) =
+      (twirlBlockComment, CommentBlock.twirlBlock(licenseText))
+  }
+
 }

--- a/src/main/scala/de/heikoseeberger/sbtheader/CommentStyle.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/CommentStyle.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.heikoseeberger.sbtheader
+
+/**
+  * Representation of the different comment styles supported by this plugin.
+  */
+sealed trait CommentStyle
+
+case object CStyleBlockComment extends CommentStyle
+
+case object CppStyleLineComment extends CommentStyle
+
+case object HashLineComment extends CommentStyle
+
+case object TwirlStyleComment extends CommentStyle
+
+case object TwirlStyleBlockComment extends CommentStyle

--- a/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala
@@ -19,6 +19,8 @@ package de.heikoseeberger.sbtheader
 import java.io.{ File, FileInputStream }
 import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.Files
+
+import de.heikoseeberger.sbtheader.CommentStyle.CStyleBlockComment
 import sbt.Keys.{ compile, streams, unmanagedResources, unmanagedSources }
 import sbt.plugins.JvmPlugin
 import sbt.{
@@ -34,6 +36,7 @@ import sbt.{
   TaskKey,
   Test
 }
+
 import scala.collection.breakOut
 import scala.util.matching.Regex
 

--- a/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala
@@ -71,17 +71,17 @@ object HeaderPlugin extends AutoPlugin {
 
     object HeaderCommentStyleMapping {
 
-      val javaBlockComments: (String, String) =
-        "java" -> "*"
+      val javaBlockComments: (String, CommentStyle) =
+        "java" -> CStyleBlockComment
 
-      val scalaBlockComments: (String, String) =
-        "scala" -> "*"
+      val scalaBlockComments: (String, CommentStyle) =
+        "scala" -> CStyleBlockComment
 
       def createFrom(
           license: License,
           yyyy: String,
           copyrightOwner: String,
-          mappings: Seq[(String, String)] = Vector(javaBlockComments, scalaBlockComments)
+          mappings: Seq[(String, CommentStyle)] = Vector(javaBlockComments, scalaBlockComments)
       ): Map[String, (Regex, String)] =
         mappings.map { case (a, b) => a -> license(yyyy, copyrightOwner, b) }(breakOut)
     }

--- a/src/main/scala/de/heikoseeberger/sbtheader/License.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/License.scala
@@ -19,19 +19,12 @@ package de.heikoseeberger.sbtheader
 import scala.util.matching.Regex
 
 sealed trait License {
-  import HeaderPlugin.autoImport.HeaderPattern._
 
   def apply(yyyy: String,
             copyrightOwner: String,
             commentStyle: CommentStyle = CStyleBlockComment): (Regex, String) = {
     val text = createLicenseText(yyyy, copyrightOwner)
-    commentStyle match {
-      case CStyleBlockComment     => (cStyleBlockComment, CommentBlock.cStyle(text))
-      case HashLineComment        => (hashLineComment, CommentBlock.hashLines(text))
-      case CppStyleLineComment    => (cppStyleLineComment, CommentBlock.cppStyle(text))
-      case TwirlStyleBlockComment => (twirlBlockComment, CommentBlock.twirlBlock(text))
-      case TwirlStyleComment      => (twirlStyleComment, CommentBlock.twirlStyle(text))
-    }
+    commentStyle(text)
   }
 
   def createLicenseText(yyyy: String, copyrightOwner: String): String

--- a/src/main/scala/de/heikoseeberger/sbtheader/License.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/License.scala
@@ -21,16 +21,16 @@ import scala.util.matching.Regex
 sealed trait License {
   import HeaderPlugin.autoImport.HeaderPattern._
 
-  def apply(yyyy: String, copyrightOwner: String, commentStyle: String = "*"): (Regex, String) = {
+  def apply(yyyy: String,
+            copyrightOwner: String,
+            commentStyle: CommentStyle = CStyleBlockComment): (Regex, String) = {
     val text = createLicenseText(yyyy, copyrightOwner)
     commentStyle match {
-      case "*"   => (cStyleBlockComment, CommentBlock.cStyle(text))
-      case "#"   => (hashLineComment, CommentBlock.hashLines(text))
-      case "//"  => (cppStyleLineComment, CommentBlock.cppStyle(text))
-      case "@**" => (twirlBlockComment, CommentBlock.twirlBlock(text))
-      case "@*"  => (twirlStyleComment, CommentBlock.twirlStyle(text))
-      case _ =>
-        throw new IllegalArgumentException(s"Comment style '$commentStyle' not supported")
+      case CStyleBlockComment     => (cStyleBlockComment, CommentBlock.cStyle(text))
+      case HashLineComment        => (hashLineComment, CommentBlock.hashLines(text))
+      case CppStyleLineComment    => (cppStyleLineComment, CommentBlock.cppStyle(text))
+      case TwirlStyleBlockComment => (twirlBlockComment, CommentBlock.twirlBlock(text))
+      case TwirlStyleComment      => (twirlStyleComment, CommentBlock.twirlStyle(text))
     }
   }
 

--- a/src/main/scala/de/heikoseeberger/sbtheader/License.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/License.scala
@@ -16,6 +16,8 @@
 
 package de.heikoseeberger.sbtheader
 
+import de.heikoseeberger.sbtheader.CommentStyle.CStyleBlockComment
+
 import scala.util.matching.Regex
 
 sealed trait License {

--- a/src/sbt-test/sbt-header/play-twirl/test.sbt
+++ b/src/sbt-test/sbt-header/play-twirl/test.sbt
@@ -1,6 +1,7 @@
 import play.twirl.sbt.Import.TwirlKeys
+import de.heikoseeberger.sbtheader.TwirlStyleBlockComment
 
-headers := Map("html" -> HeaderLicense.Apache2_0("2015", "Heiko Seeberger", "@**"))
+headers := Map("html" -> HeaderLicense.Apache2_0("2015", "Heiko Seeberger", TwirlStyleBlockComment))
 
 unmanagedSources.in(Compile, headerCreate) ++= sources.in(Compile, TwirlKeys.compileTemplates).value
 

--- a/src/sbt-test/sbt-header/play-twirl/test.sbt
+++ b/src/sbt-test/sbt-header/play-twirl/test.sbt
@@ -1,5 +1,5 @@
 import play.twirl.sbt.Import.TwirlKeys
-import de.heikoseeberger.sbtheader.TwirlStyleBlockComment
+import de.heikoseeberger.sbtheader.CommentStyle.TwirlStyleBlockComment
 
 headers := Map("html" -> HeaderLicense.Apache2_0("2015", "Heiko Seeberger", TwirlStyleBlockComment))
 

--- a/src/test/scala/de/heikoseeberger/sbtheader/AGPLv3Spec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/AGPLv3Spec.scala
@@ -51,7 +51,7 @@ final class AGPLv3Spec extends WordSpec with Matchers {
     }
 
     "return the AGPLv3 license with hash style" in {
-      val (headerPattern, agplv3) = AGPLv3("2015", "Heiko Seeberger", "#")
+      val (headerPattern, agplv3) = AGPLv3("2015", "Heiko Seeberger", HashLineComment)
       val expected =
         """|# Copyright (C) 2015  Heiko Seeberger
            |#
@@ -75,7 +75,7 @@ final class AGPLv3Spec extends WordSpec with Matchers {
     }
 
     "return the AGPLv3 license with C++ style" in {
-      val (headerPattern, agplv3) = AGPLv3("2015", "Heiko Seeberger", "//")
+      val (headerPattern, agplv3) = AGPLv3("2015", "Heiko Seeberger", CppStyleLineComment)
       val expected =
         """|// Copyright (C) 2015  Heiko Seeberger
            |//
@@ -99,7 +99,7 @@ final class AGPLv3Spec extends WordSpec with Matchers {
     }
 
     "return the AGPLv3 license with Twirl block style" in {
-      val (headerPattern, agplv3) = AGPLv3("2015", "Heiko Seeberger", "@**")
+      val (headerPattern, agplv3) = AGPLv3("2015", "Heiko Seeberger", TwirlStyleBlockComment)
       val expected =
         """|@****************************************************************************
            | * Copyright (C) 2015  Heiko Seeberger                                      *
@@ -125,7 +125,7 @@ final class AGPLv3Spec extends WordSpec with Matchers {
     }
 
     "return the AGPLv3 license with Twirl style" in {
-      val (headerPattern, agplv3) = AGPLv3("2015", "Heiko Seeberger", "@*")
+      val (headerPattern, agplv3) = AGPLv3("2015", "Heiko Seeberger", TwirlStyleComment)
       val expected =
         """|@*
            | * Copyright (C) 2015  Heiko Seeberger
@@ -148,10 +148,6 @@ final class AGPLv3Spec extends WordSpec with Matchers {
 
       agplv3 shouldBe expected
       headerPattern shouldBe HeaderPattern.twirlStyleComment
-    }
-
-    "fail when unknown comment style prefix provided" in {
-      intercept[IllegalArgumentException] { AGPLv3("2015", "Heiko Seeberger", "???") }
     }
   }
 }

--- a/src/test/scala/de/heikoseeberger/sbtheader/AGPLv3Spec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/AGPLv3Spec.scala
@@ -16,6 +16,12 @@
 
 package de.heikoseeberger.sbtheader
 
+import de.heikoseeberger.sbtheader.CommentStyle.{
+  CppStyleLineComment,
+  HashLineComment,
+  TwirlStyleBlockComment,
+  TwirlStyleComment
+}
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.HeaderLicense.AGPLv3
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.HeaderPattern
 import org.scalatest.{ Matchers, WordSpec }

--- a/src/test/scala/de/heikoseeberger/sbtheader/Apache2_0Spec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/Apache2_0Spec.scala
@@ -50,7 +50,7 @@ final class Apache2_0Spec extends WordSpec with Matchers {
     }
 
     "return the Apache 2.0 license with hash style" in {
-      val (headerPattern, apache2_0) = Apache2_0("2015", "Heiko Seeberger", "#")
+      val (headerPattern, apache2_0) = Apache2_0("2015", "Heiko Seeberger", HashLineComment)
       val expected =
         """|# Copyright 2015 Heiko Seeberger
            |#
@@ -73,7 +73,7 @@ final class Apache2_0Spec extends WordSpec with Matchers {
     }
 
     "return the Apache 2.0 license with C++ style" in {
-      val (headerPattern, apache2_0) = Apache2_0("2015", "Heiko Seeberger", "//")
+      val (headerPattern, apache2_0) = Apache2_0("2015", "Heiko Seeberger", CppStyleLineComment)
       val expected =
         """|// Copyright 2015 Heiko Seeberger
            |//
@@ -96,7 +96,7 @@ final class Apache2_0Spec extends WordSpec with Matchers {
     }
 
     "return the Apache 2.0 license with Twirl block style" in {
-      val (headerPattern, apache2_0) = Apache2_0("2015", "Heiko Seeberger", "@**")
+      val (headerPattern, apache2_0) = Apache2_0("2015", "Heiko Seeberger", TwirlStyleBlockComment)
       val expected =
         """|@****************************************************************************
            | * Copyright 2015 Heiko Seeberger                                           *
@@ -121,7 +121,7 @@ final class Apache2_0Spec extends WordSpec with Matchers {
     }
 
     "return the Apache 2.0 license with Twirl style" in {
-      val (headerPattern, apache2_0) = Apache2_0("2015", "Heiko Seeberger", "@*")
+      val (headerPattern, apache2_0) = Apache2_0("2015", "Heiko Seeberger", TwirlStyleComment)
       val expected =
         """|@*
            | * Copyright 2015 Heiko Seeberger
@@ -143,10 +143,6 @@ final class Apache2_0Spec extends WordSpec with Matchers {
 
       apache2_0 shouldBe expected
       headerPattern shouldBe HeaderPattern.twirlStyleComment
-    }
-
-    "fail when unknown comment style prefix provided" in {
-      intercept[IllegalArgumentException] { Apache2_0("2015", "Heiko Seeberger", "???") }
     }
   }
 }

--- a/src/test/scala/de/heikoseeberger/sbtheader/Apache2_0Spec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/Apache2_0Spec.scala
@@ -16,6 +16,12 @@
 
 package de.heikoseeberger.sbtheader
 
+import de.heikoseeberger.sbtheader.CommentStyle.{
+  CppStyleLineComment,
+  HashLineComment,
+  TwirlStyleBlockComment,
+  TwirlStyleComment
+}
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.HeaderLicense.Apache2_0
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.HeaderPattern
 import org.scalatest.{ Matchers, WordSpec }

--- a/src/test/scala/de/heikoseeberger/sbtheader/BSD2ClauseSpec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/BSD2ClauseSpec.scala
@@ -60,7 +60,7 @@ final class BSD2ClauseSpec extends WordSpec with Matchers {
     }
 
     "return the BSD 2 Clause license with hash style" in {
-      val (headerPattern, bsd2) = BSD2Clause("2015", "Heiko Seeberger", "#")
+      val (headerPattern, bsd2) = BSD2Clause("2015", "Heiko Seeberger", HashLineComment)
       val expected =
         s"""|# Copyright (c) 2015, Heiko Seeberger
             |# All rights reserved.
@@ -93,7 +93,7 @@ final class BSD2ClauseSpec extends WordSpec with Matchers {
     }
 
     "return the BSD 2 Clause license with C++ style" in {
-      val (headerPattern, bsd2) = BSD2Clause("2015", "Heiko Seeberger", "//")
+      val (headerPattern, bsd2) = BSD2Clause("2015", "Heiko Seeberger", CppStyleLineComment)
       val expected =
         s"""|// Copyright (c) 2015, Heiko Seeberger
             |// All rights reserved.
@@ -126,7 +126,7 @@ final class BSD2ClauseSpec extends WordSpec with Matchers {
     }
 
     "return the BSD 2 Clause license with Twirl block style" in {
-      val (headerPattern, bsd2) = BSD2Clause("2015", "Heiko Seeberger", "@**")
+      val (headerPattern, bsd2) = BSD2Clause("2015", "Heiko Seeberger", TwirlStyleBlockComment)
       val expected =
         s"""|@************************************************************************************
             | * Copyright (c) 2015, Heiko Seeberger                                              *
@@ -161,7 +161,7 @@ final class BSD2ClauseSpec extends WordSpec with Matchers {
     }
 
     "return the BSD 2 Clause license with Twirl style " in {
-      val (headerPattern, bsd2) = BSD2Clause("2015", "Heiko Seeberger", "@*")
+      val (headerPattern, bsd2) = BSD2Clause("2015", "Heiko Seeberger", TwirlStyleComment)
       val expected =
         s"""|@*
             | * Copyright (c) 2015, Heiko Seeberger
@@ -193,10 +193,6 @@ final class BSD2ClauseSpec extends WordSpec with Matchers {
 
       bsd2 shouldBe expected
       headerPattern shouldBe HeaderPattern.twirlStyleComment
-    }
-
-    "fail when unknown comment style prefix provided" in {
-      intercept[IllegalArgumentException] { BSD2Clause("2015", "Heiko Seeberger", "???") }
     }
   }
 }

--- a/src/test/scala/de/heikoseeberger/sbtheader/BSD2ClauseSpec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/BSD2ClauseSpec.scala
@@ -16,6 +16,12 @@
 
 package de.heikoseeberger.sbtheader
 
+import de.heikoseeberger.sbtheader.CommentStyle.{
+  CppStyleLineComment,
+  HashLineComment,
+  TwirlStyleBlockComment,
+  TwirlStyleComment
+}
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.HeaderLicense.BSD2Clause
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.HeaderPattern
 import org.scalatest.{ Matchers, WordSpec }

--- a/src/test/scala/de/heikoseeberger/sbtheader/BSD3ClauseSpec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/BSD3ClauseSpec.scala
@@ -64,7 +64,7 @@ final class BSD3ClauseSpec extends WordSpec with Matchers {
     }
 
     "return the BSD 3 Clause license with hash style" in {
-      val (headerPattern, bsd3) = BSD3Clause("2015", "Heiko Seeberger", "#")
+      val (headerPattern, bsd3) = BSD3Clause("2015", "Heiko Seeberger", HashLineComment)
       val expected =
         s"""|# Copyright (c) 2015, Heiko Seeberger
             |# All rights reserved.
@@ -101,7 +101,7 @@ final class BSD3ClauseSpec extends WordSpec with Matchers {
     }
 
     "return the BSD 3 Clause license with C++ style" in {
-      val (headerPattern, bsd3) = BSD3Clause("2015", "Heiko Seeberger", "//")
+      val (headerPattern, bsd3) = BSD3Clause("2015", "Heiko Seeberger", CppStyleLineComment)
       val expected =
         s"""|// Copyright (c) 2015, Heiko Seeberger
             |// All rights reserved.
@@ -138,7 +138,7 @@ final class BSD3ClauseSpec extends WordSpec with Matchers {
     }
 
     "return the BSD 3 Clause license with Twirl block style" in {
-      val (headerPattern, bsd3) = BSD3Clause("2015", "Heiko Seeberger", "@**")
+      val (headerPattern, bsd3) = BSD3Clause("2015", "Heiko Seeberger", TwirlStyleBlockComment)
       val expected =
         s"""|@************************************************************************************
             | * Copyright (c) 2015, Heiko Seeberger                                              *
@@ -177,7 +177,7 @@ final class BSD3ClauseSpec extends WordSpec with Matchers {
     }
 
     "return the BSD 3 Clause license with Twirl style" in {
-      val (headerPattern, bsd3) = BSD3Clause("2015", "Heiko Seeberger", "@*")
+      val (headerPattern, bsd3) = BSD3Clause("2015", "Heiko Seeberger", TwirlStyleComment)
       val expected =
         s"""|@*
             | * Copyright (c) 2015, Heiko Seeberger
@@ -213,10 +213,6 @@ final class BSD3ClauseSpec extends WordSpec with Matchers {
 
       bsd3 shouldBe expected
       headerPattern shouldBe HeaderPattern.twirlStyleComment
-    }
-
-    "fail when unknown comment style prefix provided" in {
-      intercept[IllegalArgumentException] { BSD3Clause("2015", "Heiko Seeberger", "???") }
     }
   }
 }

--- a/src/test/scala/de/heikoseeberger/sbtheader/BSD3ClauseSpec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/BSD3ClauseSpec.scala
@@ -16,6 +16,12 @@
 
 package de.heikoseeberger.sbtheader
 
+import de.heikoseeberger.sbtheader.CommentStyle.{
+  CppStyleLineComment,
+  HashLineComment,
+  TwirlStyleBlockComment,
+  TwirlStyleComment
+}
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.HeaderLicense.BSD3Clause
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.HeaderPattern
 import org.scalatest.{ Matchers, WordSpec }

--- a/src/test/scala/de/heikoseeberger/sbtheader/GPLv3Spec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/GPLv3Spec.scala
@@ -51,7 +51,7 @@ final class GPLv3Spec extends WordSpec with Matchers {
     }
 
     "return the GPLv3 license with hash style" in {
-      val (headerPattern, gplv3) = GPLv3("2015", "Heiko Seeberger", "#")
+      val (headerPattern, gplv3) = GPLv3("2015", "Heiko Seeberger", HashLineComment)
       val expected =
         """|# Copyright (C) 2015  Heiko Seeberger
            |#
@@ -75,7 +75,7 @@ final class GPLv3Spec extends WordSpec with Matchers {
     }
 
     "return the GPLv3 license with C++ style" in {
-      val (headerPattern, gplv3) = GPLv3("2015", "Heiko Seeberger", "//")
+      val (headerPattern, gplv3) = GPLv3("2015", "Heiko Seeberger", CppStyleLineComment)
       val expected =
         """|// Copyright (C) 2015  Heiko Seeberger
            |//
@@ -99,7 +99,7 @@ final class GPLv3Spec extends WordSpec with Matchers {
     }
 
     "return the GPLv3 license with Twirl block style" in {
-      val (headerPattern, gplv3) = GPLv3("2015", "Heiko Seeberger", "@**")
+      val (headerPattern, gplv3) = GPLv3("2015", "Heiko Seeberger", TwirlStyleBlockComment)
       val expected =
         """|@*************************************************************************
            | * Copyright (C) 2015  Heiko Seeberger                                   *
@@ -125,7 +125,7 @@ final class GPLv3Spec extends WordSpec with Matchers {
     }
 
     "return the GPLv3 license with Twirl style" in {
-      val (headerPattern, gplv3) = GPLv3("2015", "Heiko Seeberger", "@*")
+      val (headerPattern, gplv3) = GPLv3("2015", "Heiko Seeberger", TwirlStyleComment)
       val expected =
         s"""|@*
             | * Copyright (C) 2015  Heiko Seeberger
@@ -148,10 +148,6 @@ final class GPLv3Spec extends WordSpec with Matchers {
 
       gplv3 shouldBe expected
       headerPattern shouldBe HeaderPattern.twirlStyleComment
-    }
-
-    "fail when unknown comment style prefix provided" in {
-      intercept[IllegalArgumentException] { GPLv3("2015", "Heiko Seeberger", "???") }
     }
   }
 }

--- a/src/test/scala/de/heikoseeberger/sbtheader/GPLv3Spec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/GPLv3Spec.scala
@@ -16,6 +16,12 @@
 
 package de.heikoseeberger.sbtheader
 
+import de.heikoseeberger.sbtheader.CommentStyle.{
+  CppStyleLineComment,
+  HashLineComment,
+  TwirlStyleBlockComment,
+  TwirlStyleComment
+}
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.HeaderLicense.GPLv3
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.HeaderPattern
 import org.scalatest.{ Matchers, WordSpec }

--- a/src/test/scala/de/heikoseeberger/sbtheader/HeaderCommentStyleMappingSpec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/HeaderCommentStyleMappingSpec.scala
@@ -47,7 +47,7 @@ final class HeaderCommentStyleMappingSpec extends WordSpec with Matchers {
       HeaderLicense.Apache2_0,
       "2016",
       "John Doe",
-      Vector("conf" -> "#", "properties" -> "#", "yml" -> "#")
+      Vector("conf" -> HashLineComment, "properties" -> HashLineComment, "yml" -> HashLineComment)
     )
 
     "map conf files to hash line comments" in {

--- a/src/test/scala/de/heikoseeberger/sbtheader/HeaderCommentStyleMappingSpec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/HeaderCommentStyleMappingSpec.scala
@@ -16,6 +16,7 @@
 
 package de.heikoseeberger.sbtheader
 
+import de.heikoseeberger.sbtheader.CommentStyle.HashLineComment
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.HeaderPattern.{
   cStyleBlockComment,
   hashLineComment

--- a/src/test/scala/de/heikoseeberger/sbtheader/LGPLv3Spec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/LGPLv3Spec.scala
@@ -16,6 +16,12 @@
 
 package de.heikoseeberger.sbtheader
 
+import de.heikoseeberger.sbtheader.CommentStyle.{
+  CppStyleLineComment,
+  HashLineComment,
+  TwirlStyleBlockComment,
+  TwirlStyleComment
+}
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.HeaderLicense.LGPLv3
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.HeaderPattern
 import org.scalatest.{ Matchers, WordSpec }

--- a/src/test/scala/de/heikoseeberger/sbtheader/LGPLv3Spec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/LGPLv3Spec.scala
@@ -51,7 +51,7 @@ final class LGPLv3Spec extends WordSpec with Matchers {
     }
 
     "return the LGPLv3 license with hash style" in {
-      val (headerPattern, lgplv3) = LGPLv3("2015", "Heiko Seeberger", "#")
+      val (headerPattern, lgplv3) = LGPLv3("2015", "Heiko Seeberger", HashLineComment)
       val expected =
         """|# Copyright (C) 2015  Heiko Seeberger
            |#
@@ -75,7 +75,7 @@ final class LGPLv3Spec extends WordSpec with Matchers {
     }
 
     "return the LGPLv3 license with C++ style" in {
-      val (headerPattern, lgplv3) = LGPLv3("2015", "Heiko Seeberger", "//")
+      val (headerPattern, lgplv3) = LGPLv3("2015", "Heiko Seeberger", CppStyleLineComment)
       val expected =
         """|// Copyright (C) 2015  Heiko Seeberger
            |//
@@ -99,7 +99,7 @@ final class LGPLv3Spec extends WordSpec with Matchers {
     }
 
     "return the LGPLv3 license with Twirl block style" in {
-      val (headerPattern, lgplv3) = LGPLv3("2015", "Heiko Seeberger", "@**")
+      val (headerPattern, lgplv3) = LGPLv3("2015", "Heiko Seeberger", TwirlStyleBlockComment)
       val expected =
         """|@****************************************************************************
            | * Copyright (C) 2015  Heiko Seeberger                                      *
@@ -125,7 +125,7 @@ final class LGPLv3Spec extends WordSpec with Matchers {
     }
 
     "return the LGPLv3 license with Twirl style" in {
-      val (headerPattern, lgplv3) = LGPLv3("2015", "Heiko Seeberger", "@*")
+      val (headerPattern, lgplv3) = LGPLv3("2015", "Heiko Seeberger", TwirlStyleComment)
       val expected =
         s"""|@*
             | * Copyright (C) 2015  Heiko Seeberger
@@ -148,10 +148,6 @@ final class LGPLv3Spec extends WordSpec with Matchers {
 
       lgplv3 shouldBe expected
       headerPattern shouldBe HeaderPattern.twirlStyleComment
-    }
-
-    "fail when unknown comment style prefix provided" in {
-      intercept[IllegalArgumentException] { LGPLv3("2015", "Heiko Seeberger", "???") }
     }
   }
 }

--- a/src/test/scala/de/heikoseeberger/sbtheader/MITSpec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/MITSpec.scala
@@ -16,6 +16,12 @@
 
 package de.heikoseeberger.sbtheader
 
+import de.heikoseeberger.sbtheader.CommentStyle.{
+  CppStyleLineComment,
+  HashLineComment,
+  TwirlStyleBlockComment,
+  TwirlStyleComment
+}
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.HeaderLicense.MIT
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.HeaderPattern
 import org.scalatest.{ Matchers, WordSpec }

--- a/src/test/scala/de/heikoseeberger/sbtheader/MITSpec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/MITSpec.scala
@@ -55,7 +55,7 @@ final class MITSpec extends WordSpec with Matchers {
     }
 
     "return the MIT license with hash style" in {
-      val (headerPattern, mit) = MIT("2015", "Heiko Seeberger", "#")
+      val (headerPattern, mit) = MIT("2015", "Heiko Seeberger", HashLineComment)
       val expected =
         s"""|# Copyright (c) 2015 Heiko Seeberger
             |#
@@ -83,7 +83,7 @@ final class MITSpec extends WordSpec with Matchers {
     }
 
     "return the MIT license with C++ style" in {
-      val (headerPattern, mit) = MIT("2015", "Heiko Seeberger", "//")
+      val (headerPattern, mit) = MIT("2015", "Heiko Seeberger", CppStyleLineComment)
       val expected =
         s"""|// Copyright (c) 2015 Heiko Seeberger
             |//
@@ -111,7 +111,7 @@ final class MITSpec extends WordSpec with Matchers {
     }
 
     "return the MIT license with Twirl block style" in {
-      val (headerPattern, mit) = MIT("2015", "Heiko Seeberger", "@**")
+      val (headerPattern, mit) = MIT("2015", "Heiko Seeberger", TwirlStyleBlockComment)
       val expected =
         s"""|@************************************************************************************
             | * Copyright (c) 2015 Heiko Seeberger                                               *
@@ -141,7 +141,7 @@ final class MITSpec extends WordSpec with Matchers {
     }
 
     "return the MIT license with Twirl style" in {
-      val (headerPattern, mit) = MIT("2015", "Heiko Seeberger", "@*")
+      val (headerPattern, mit) = MIT("2015", "Heiko Seeberger", TwirlStyleComment)
       val expected =
         s"""|@*
             | * Copyright (c) 2015 Heiko Seeberger
@@ -168,10 +168,6 @@ final class MITSpec extends WordSpec with Matchers {
 
       mit shouldBe expected
       headerPattern shouldBe HeaderPattern.twirlStyleComment
-    }
-
-    "fail when unknown comment style prefix provided" in {
-      intercept[IllegalArgumentException] { MIT("2015", "Heiko Seeberger", "???") }
     }
   }
 }

--- a/src/test/scala/de/heikoseeberger/sbtheader/MPLv2Spec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/MPLv2Spec.scala
@@ -60,7 +60,7 @@ final class MPLv2Spec extends WordSpec with Matchers {
     }
 
     "return the MPL 2.0 license with hash style" in {
-      val (headerPattern, mit) = MPLv2("2015", "Heiko Seeberger", "#")
+      val (headerPattern, mit) = MPLv2("2015", "Heiko Seeberger", HashLineComment)
       val expected =
         s"""|# Copyright (c) 2015 Heiko Seeberger
             |#
@@ -75,7 +75,7 @@ final class MPLv2Spec extends WordSpec with Matchers {
     }
 
     "return the MIT license with C++ style" in {
-      val (headerPattern, mit) = MPLv2("2015", "Heiko Seeberger", "//")
+      val (headerPattern, mit) = MPLv2("2015", "Heiko Seeberger", CppStyleLineComment)
       val expected =
         s"""|// Copyright (c) 2015 Heiko Seeberger
             |//
@@ -90,7 +90,7 @@ final class MPLv2Spec extends WordSpec with Matchers {
     }
 
     "return the MIT license with Twirl block style" in {
-      val (headerPattern, mit) = MPLv2("2015", "Heiko Seeberger", "@**")
+      val (headerPattern, mit) = MPLv2("2015", "Heiko Seeberger", TwirlStyleBlockComment)
       val expected =
         s"""|@***********************************************************************
             | * Copyright (c) 2015 Heiko Seeberger                                  *
@@ -107,7 +107,7 @@ final class MPLv2Spec extends WordSpec with Matchers {
     }
 
     "return the MPL 2.0 license with Twirl style" in {
-      val (headerPattern, mit) = MPLv2("2015", "Heiko Seeberger", "@*")
+      val (headerPattern, mit) = MPLv2("2015", "Heiko Seeberger", TwirlStyleComment)
       val expected =
         s"""|@*
             | * Copyright (c) 2015 Heiko Seeberger
@@ -121,10 +121,6 @@ final class MPLv2Spec extends WordSpec with Matchers {
 
       mit shouldBe expected
       headerPattern shouldBe HeaderPattern.twirlStyleComment
-    }
-
-    "fail when unknown comment style prefix provided" in {
-      intercept[IllegalArgumentException] { MPLv2("2015", "Heiko Seeberger", "???") }
     }
   }
 }

--- a/src/test/scala/de/heikoseeberger/sbtheader/MPLv2Spec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/MPLv2Spec.scala
@@ -16,6 +16,12 @@
 
 package de.heikoseeberger.sbtheader
 
+import de.heikoseeberger.sbtheader.CommentStyle.{
+  CppStyleLineComment,
+  HashLineComment,
+  TwirlStyleBlockComment,
+  TwirlStyleComment
+}
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.HeaderLicense.{
   MPLv2,
   MPLv2_NoCopyright


### PR DESCRIPTION
This is my initial approach to fix #78. This change makes the match in `License` exhausive and prepares the code for further refactorings. If this is the right direction, we should probably merge the `CommentStyles` with their respective `HeaderPattern` and `CommentBlock`.