### PR TITLE
License auto-detection

### DIFF
--- a/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala
@@ -137,10 +137,7 @@ object HeaderPlugin extends AutoPlugin {
           .toList ++ unmanagedResources.in(headerCreate).value.toList,
         headerLicense.value
           .getOrElse(
-            LicenseDetection(licenses.value.toList, organizationName.value, startYear.value)
-              .getOrElse(
-                sys.error("Unable to auto detect project license")
-              )
+            sys.error("Unable to auto detect project license")
           ),
         headerMappings.value,
         streams.value.log
@@ -152,10 +149,7 @@ object HeaderPlugin extends AutoPlugin {
           .toList ++ unmanagedResources.in(headerCreate).value.toList,
         headerLicense.value
           .getOrElse(
-            LicenseDetection(licenses.value.toList, organizationName.value, startYear.value)
-              .getOrElse(
-                sys.error("Unable to auto detect project license")
-              )
+            sys.error("Unable to auto detect project license")
           ),
         headerMappings.value,
         streams.value.log
@@ -165,7 +159,9 @@ object HeaderPlugin extends AutoPlugin {
   private def notToBeScopedSettings =
     Vector(
       headerMappings := Map.empty,
-      headerLicense := None
+      headerLicense := LicenseDetection(licenses.value.toList,
+                                        organizationName.value,
+                                        startYear.value)
     )
 
   private def createHeadersTask(files: Seq[File],

--- a/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala
@@ -22,7 +22,6 @@ import java.nio.file.Files
 
 import de.heikoseeberger.sbtheader.CommentStyle.CStyleBlockComment
 import sbt.Keys.{
-  compile,
   licenses,
   organizationName,
   startYear,

--- a/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala
@@ -137,7 +137,10 @@ object HeaderPlugin extends AutoPlugin {
           .toList ++ unmanagedResources.in(headerCreate).value.toList,
         headerLicense.value
           .getOrElse(
-            detectLicense(licenses.value.toList, organizationName.value, startYear.value)
+            LicenseDetection(licenses.value.toList, organizationName.value, startYear.value)
+              .getOrElse(
+                sys.error("Unable to auto detect project license")
+              )
           ),
         headerMappings.value,
         streams.value.log
@@ -149,18 +152,14 @@ object HeaderPlugin extends AutoPlugin {
           .toList ++ unmanagedResources.in(headerCreate).value.toList,
         headerLicense.value
           .getOrElse(
-            detectLicense(licenses.value.toList, organizationName.value, startYear.value)
+            LicenseDetection(licenses.value.toList, organizationName.value, startYear.value)
+              .getOrElse(
+                sys.error("Unable to auto detect project license")
+              )
           ),
         headerMappings.value,
         streams.value.log
       )
-    )
-
-  private def detectLicense(licenses: List[(String, URL)],
-                            organizationName: String,
-                            startYear: Option[Int]): License =
-    LicenseDetection(licenses, organizationName, startYear).getOrElse(
-      sys.error("Unable to auto detect project license")
     )
 
   private def notToBeScopedSettings =

--- a/src/main/scala/de/heikoseeberger/sbtheader/LicenseDetection.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/LicenseDetection.scala
@@ -39,21 +39,12 @@ private object LicenseDetection {
       case (name, _) :: Nil => Some(name)
       case _                => None
     }
-    val org = organizationName.trim match {
-      case "" => None
-      case _  => Some(organizationName)
-    }
-    detectLicense(licenseName, org, startYear)
-  }
 
-  private def detectLicense(licenseName: Option[String],
-                            organizationName: Option[String],
-                            startYear: Option[Int]) =
     for {
       name    <- licenseName
       license <- spdxMapping.get(name)
-      org     <- organizationName
       year    <- startYear
-    } yield license(year.toString, org)
+    } yield license(year.toString, organizationName)
+  }
 
 }

--- a/src/main/scala/de/heikoseeberger/sbtheader/LicenseDetection.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/LicenseDetection.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.heikoseeberger.sbtheader
+
+import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.HeaderLicense._
+import sbt.URL
+
+private object LicenseDetection {
+
+  private val spdxMapping = Map(
+    "Apache-2.0"   -> Apache2_0,
+    "AGPL-3.0"     -> AGPLv3,
+    "BSD-2-Clause" -> BSD2Clause,
+    "BSD-3-Clause" -> BSD3Clause,
+    "GPL-3.0"      -> GPLv3,
+    "LGPL-3.0"     -> LGPLv3,
+    "MIT"          -> MIT,
+    "MPL-2.0"      -> MPLv2
+  )
+
+  def apply(licenses: Seq[(String, URL)],
+            organizationName: String,
+            startYear: Option[Int]): Option[License] = {
+    val licenseName = licenses match {
+      case license :: Nil => Some(license._1)
+      case _              => None
+    }
+    val org = organizationName.trim match {
+      case "" => None
+      case _  => Some(organizationName)
+    }
+    detectLicense(licenseName, org, startYear)
+  }
+
+  private def detectLicense(licenseName: Option[String],
+                            organizationName: Option[String],
+                            startYear: Option[Int]) =
+    for {
+      name    <- licenseName
+      license <- spdxMapping.get(name)
+      org     <- organizationName
+      year    <- startYear
+    } yield license(year.toString, org)
+
+}

--- a/src/main/scala/de/heikoseeberger/sbtheader/LicenseDetection.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/LicenseDetection.scala
@@ -36,8 +36,8 @@ private object LicenseDetection {
             organizationName: String,
             startYear: Option[Int]): Option[License] = {
     val licenseName = licenses match {
-      case license :: Nil => Some(license._1)
-      case _              => None
+      case (name, _) :: Nil => Some(name)
+      case _                => None
     }
     val org = organizationName.trim match {
       case "" => None

--- a/src/sbt-test/sbt-header/auto-detection/project/test.sbt
+++ b/src/sbt-test/sbt-header/auto-detection/project/test.sbt
@@ -1,0 +1,6 @@
+val pluginVersion =
+  sys.props
+    .get("plugin.version")
+    .getOrElse(sys.error("Sys prop plugin.version must be defined!"))
+
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % pluginVersion)

--- a/src/sbt-test/sbt-header/auto-detection/src/main/resources/HasNoHeader.scala_expected
+++ b/src/sbt-test/sbt-header/auto-detection/src/main/resources/HasNoHeader.scala_expected
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.heikoseeberger.sbtheader.test;
+
+class HasNoHeader

--- a/src/sbt-test/sbt-header/auto-detection/src/main/scala/HasNoHeader.scala
+++ b/src/sbt-test/sbt-header/auto-detection/src/main/scala/HasNoHeader.scala
@@ -1,0 +1,3 @@
+package de.heikoseeberger.sbtheader.test;
+
+class HasNoHeader

--- a/src/sbt-test/sbt-header/auto-detection/test
+++ b/src/sbt-test/sbt-header/auto-detection/test
@@ -1,0 +1,3 @@
+# check if headers get created
+> headerCreate
+> checkFileContents

--- a/src/sbt-test/sbt-header/auto-detection/test.sbt
+++ b/src/sbt-test/sbt-header/auto-detection/test.sbt
@@ -1,12 +1,14 @@
 import de.heikoseeberger.sbtheader.CommentStyle.CStyleBlockComment
 
-headerLicense := Some(HeaderLicense.Apache2_0("2015", "Heiko Seeberger"))
+organizationName := "Heiko Seeberger"
+startYear := Some(2015)
+licenses := List(("Apache-2.0", new URL("https://www.apache.org/licenses/LICENSE-2.0.txt")))
+
 headerMappings := Map("scala" -> CStyleBlockComment)
 
 val checkFileContents = taskKey[Unit]("Verify file contents match expected contents")
 
 checkFileContents := {
-  checkFile("HasHeader.scala")
   checkFile("HasNoHeader.scala")
 
   def checkFile(name: String) = {

--- a/src/sbt-test/sbt-header/checkHeaders-fails/test.sbt
+++ b/src/sbt-test/sbt-header/checkHeaders-fails/test.sbt
@@ -1,4 +1,4 @@
 import de.heikoseeberger.sbtheader.CommentStyle.CStyleBlockComment
 
-headerLicense := HeaderLicense.Apache2_0("2015", "Heiko Seeberger")
+headerLicense := Some(HeaderLicense.Apache2_0("2015", "Heiko Seeberger"))
 headerMappings := Map("scala" -> CStyleBlockComment)

--- a/src/sbt-test/sbt-header/checkHeaders/test.sbt
+++ b/src/sbt-test/sbt-header/checkHeaders/test.sbt
@@ -1,4 +1,4 @@
 import de.heikoseeberger.sbtheader.CommentStyle.CStyleBlockComment
 
-headerLicense := HeaderLicense.Apache2_0("2015", "Heiko Seeberger")
+headerLicense := Some(HeaderLicense.Apache2_0("2015", "Heiko Seeberger"))
 headerMappings := Map("scala" -> CStyleBlockComment)

--- a/src/sbt-test/sbt-header/custom-license/test.sbt
+++ b/src/sbt-test/sbt-header/custom-license/test.sbt
@@ -1,11 +1,11 @@
 import de.heikoseeberger.sbtheader.CommentStyle.CStyleBlockComment
 
-headerLicense := HeaderLicense.Custom(
+headerLicense := Some(HeaderLicense.Custom(
   """|This is a custom License.
      |
      |It has an empty line and a second line with Text.
      |""".stripMargin
-)
+))
 headerMappings := Map("scala" -> CStyleBlockComment)
 
 val checkFileContents = taskKey[Unit]("Verify file contents match expected contents")

--- a/src/sbt-test/sbt-header/excludes/test.sbt
+++ b/src/sbt-test/sbt-header/excludes/test.sbt
@@ -1,6 +1,6 @@
 import de.heikoseeberger.sbtheader.CommentStyle.CStyleBlockComment
 
-headerLicense := HeaderLicense.Apache2_0("2015", "Heiko Seeberger")
+headerLicense := Some(HeaderLicense.Apache2_0("2015", "Heiko Seeberger"))
 headerMappings := Map("scala" -> CStyleBlockComment)
 
 excludeFilter.in(unmanagedSources.in(headerCreate)) := HiddenFileFilter || "*Excluded.scala"

--- a/src/sbt-test/sbt-header/play-twirl/test.sbt
+++ b/src/sbt-test/sbt-header/play-twirl/test.sbt
@@ -2,7 +2,7 @@ import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport._
 import de.heikoseeberger.sbtheader.CommentStyle.TwirlStyleBlockComment
 import play.twirl.sbt.Import.TwirlKeys
 
-headerLicense := HeaderLicense.Apache2_0("2015", "Heiko Seeberger")
+headerLicense := Some(HeaderLicense.Apache2_0("2015", "Heiko Seeberger"))
 headerMappings := Map("html" -> TwirlStyleBlockComment)
 
 unmanagedSources.in(Compile, headerCreate) ++= sources.in(Compile, TwirlKeys.compileTemplates).value

--- a/src/test/scala/de/heikoseeberger/sbtheader/LicenseDetectionSpec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/LicenseDetectionSpec.scala
@@ -39,16 +39,14 @@ class LicenseDetectionSpec extends WordSpec with Matchers {
       "https://spdx.org/licenses/AGPL-3.0.html#licenseText"
     )),
     Apache2_0(yyyy.toString, organizationName) ->
-    ("Apache-2.0", new URL("https://spdx.org/licenses/Apache-2.0.html#licenseText")),
+    apache,
     GPLv3(yyyy.toString, organizationName) -> ("GPL-3.0", new URL(
       "https://spdx.org/licenses/GPL-3.0.html#licenseText"
     )),
     LGPLv3(yyyy.toString, organizationName) -> ("LGPL-3.0", new URL(
       "https://spdx.org/licenses/LGPL-3.0.html#licenseText"
     )),
-    MIT(yyyy.toString, organizationName) -> ("MIT", new URL(
-      "https://spdx.org/licenses/MIT.html#licenseText"
-    )),
+    MIT(yyyy.toString, organizationName) -> mit,
     MPLv2(yyyy.toString, organizationName) -> ("MPL-2.0", new URL(
       "https://spdx.org/licenses/MPL-2.0.html#licenseText"
     ))

--- a/src/test/scala/de/heikoseeberger/sbtheader/LicenseDetectionSpec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/LicenseDetectionSpec.scala
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.heikoseeberger.sbtheader
+
+import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.HeaderLicense._
+import org.scalatest.{ Matchers, WordSpec }
+import sbt.URL
+
+class LicenseDetectionSpec extends WordSpec with Matchers {
+
+  val organizationName = "Heiko Seeberger"
+  val yyyy             = 2017
+  val startYear        = Some(yyyy)
+  val apache           = ("Apache-2.0", new URL("https://spdx.org/licenses/Apache-2.0.html#licenseText"))
+  val mit              = ("MIT", new URL("https://spdx.org/licenses/MIT.html#licenseText"))
+
+  val licenses = Map(
+    BSD2Clause(yyyy.toString, organizationName) -> ("BSD-2-Clause", new URL(
+      "https://spdx.org/licenses/BSD-2-Clause.html#licenseText"
+    )),
+    BSD3Clause(yyyy.toString, organizationName) -> ("BSD-3-Clause", new URL(
+      "https://spdx.org/licenses/BSD-3-Clause.html#licenseText"
+    )),
+    AGPLv3(yyyy.toString, organizationName) -> ("AGPL-3.0", new URL(
+      "https://spdx.org/licenses/AGPL-3.0.html#licenseText"
+    )),
+    Apache2_0(yyyy.toString, organizationName) ->
+    ("Apache-2.0", new URL("https://spdx.org/licenses/Apache-2.0.html#licenseText")),
+    GPLv3(yyyy.toString, organizationName) -> ("GPL-3.0", new URL(
+      "https://spdx.org/licenses/GPL-3.0.html#licenseText"
+    )),
+    LGPLv3(yyyy.toString, organizationName) -> ("LGPL-3.0", new URL(
+      "https://spdx.org/licenses/LGPL-3.0.html#licenseText"
+    )),
+    MIT(yyyy.toString, organizationName) -> ("MIT", new URL(
+      "https://spdx.org/licenses/MIT.html#licenseText"
+    )),
+    MPLv2(yyyy.toString, organizationName) -> ("MPL-2.0", new URL(
+      "https://spdx.org/licenses/MPL-2.0.html#licenseText"
+    ))
+  )
+
+  "LicenseDetection" should {
+    "not detect a license when sbt licenses is empty" in {
+      LicenseDetection(List.empty, organizationName, startYear) shouldBe None
+    }
+
+    "not detect a license when sbt licenses contains two licenses" in {
+      LicenseDetection(
+        List(apache, mit),
+        organizationName,
+        startYear
+      ) shouldBe None
+    }
+
+    // TODO is the value of the setting empty, when the user has not set it?
+    "not detect a license when organzationName is empty" in {
+      LicenseDetection(
+        List(apache),
+        "",
+        startYear
+      ) shouldBe None
+    }
+
+    "not detect a license when startYear is None" in {
+      LicenseDetection(
+        List(apache),
+        organizationName,
+        None
+      ) shouldBe None
+    }
+
+    licenses.foreach {
+      case (license, sbtLicense) =>
+        s"detect ${license.getClass.getSimpleName} license" in {
+          LicenseDetection(List(sbtLicense), organizationName, startYear) shouldBe Some(
+            license
+          )
+        }
+    }
+  }
+}

--- a/src/test/scala/de/heikoseeberger/sbtheader/LicenseDetectionSpec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/LicenseDetectionSpec.scala
@@ -67,15 +67,6 @@ class LicenseDetectionSpec extends WordSpec with Matchers {
       ) shouldBe None
     }
 
-    // TODO is the value of the setting empty, when the user has not set it?
-    "not detect a license when organzationName is empty" in {
-      LicenseDetection(
-        List(apache),
-        "",
-        startYear
-      ) shouldBe None
-    }
-
     "not detect a license when startYear is None" in {
       LicenseDetection(
         List(apache),


### PR DESCRIPTION
Fix for #73: Detect the project license based on the `licenses`, `organizationName` and `startYear` settings.

Note that `licenses` is of type `Seq((String, URL))`. The current implementation can only detect a license if `licenses` has only one entry. If there is exactly one entry the String has to contain a [SPDX license identifier](http://spdx.org/licenses/), which we than map to one of the licenses we support.

Users can still set the license directly by specifying the `headerLicense` setting. Is the `headerLicense` is set, it's value is given precedence.