### PR TITLE
Rewrite of the documentation for 2.0.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,12 +220,78 @@ either `Compile` or `Test`.
 
 ## Migrating from 1.x
 
-TODO
+This section contains migration notes from version 1.x of sbt-header to version 2.x. The latest release of the 1.x line is 1.8.0. You can find the documentation of that release in the [corresponding git tag](https://github.com/sbt/sbt-header/tree/v1.8.0).
 
-- link to old documentation
-- renamed tasks and settings
-- migrating to `Custom` license
-- features which doe not work anymore: appling different licenses to different file types
+### Changed task names and settings keys
+
+The names of all tasks and settings have been changed from 1.x to 2.x. Furthermore types of settings have changed. The following tables give an overview of the changes:
+
+Changed task names:
+
+|Old Name|New Name|
+|--------|--------|
+|`createHeaders`|`headerCreate`|
+|`checkHeaders`|`headerCheck`|
+
+Changed settings:
+
+|Old Name : Old Type|New Name: New Type|
+|--------|--------|
+|`headers : Map[String, (Regex, String)]`|`headerMappings : Map[FileType, CommentStyle]`|
+| - | `headerLicense : Option[License]`|
+| `exclude : Seq[String]` | removed in favor of sbt include/excude filters|
+
+### `createFrom` method
+
+sbt-header 1.x featured some default header mappings as well as the `createFrom` method, which could be used to easily define header mappings:
+
+```scala
+headers := createFrom(Apache2_0, "2015", "Heiko Seeberger")
+```
+
+This method has been removed and the default mappings for Scala and Java files has been added as default mapping to the `headerMappings` setting.
+
+### Custom licenses
+
+In sbt-header 1.x when you needed to use a custom license this would typically look like this:
+
+```scala
+headers := Map(
+  "scala" -> (
+    HeaderPattern.cStyleBlockComment,
+    """|/*
+       | * Copyright 2015 Awesome Company
+       | */
+       |""".stripMargin
+  )
+)
+```
+
+In sbt-header 2.x, licenses are defined as instances of `de.hseeberger.sbtheader.License`. Further more, the license is only defined once and not per file type. So the above in 2.x is equivalent to:
+
+```scala
+headerLicense := Some(HeaderLicense.Custom(
+    """|/*
+       | * Copyright 2015 Awesome Company
+       | */
+       |""".stripMargin
+))
+```
+
+This will apply C style block comments to Java and Scala files. If you have mappings for additional file types, please add these to the `headerMappings` setting.
+
+### Dropped features
+
+In sbt-header 1.x it was possible to define different licenses for different files types, e.g.:
+
+```scala
+headers := Map(
+  "scala" -> Apache2_0("2015", "Heiko Seeberger"),
+  "java" -> MIT("2015", "Heiko Seeberger")
+)
+```
+
+Since we believe most of the projects out there will only ever have one license, we dropped this feature without replacement. In sbt-header 2.x users have to define a single license for the whole project using the `headerLicense` setting (or let sbt-header infer it from the `licenses` project setting, see [above](#getting-started)) and a mapping from file type to comment style using the `headerMappings` setting.
 
 ## Contribution policy ##
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ In order to check whether all files have headers (for example for CI), execute t
 
 ## Configuration
 
-By default sbt-header tries to infer the license header you want to use from the `orgaizationName`, `startYear` and `licenses`. For this to work, sbt-header requires the `licenses` setting to contain exactly one entry. The first component of that entry has to be the [SPDX license identifier](http://spdx.org/licenses/) of one of the [supported licenses](#build-in-licenses). 
+By default sbt-header tries to infer the license header you want to use from the `orgaizationName`, `startYear` and `licenses` settings. For this to work, sbt-header requires the `licenses` setting to contain exactly one entry. The first component of that entry has to be the [SPDX license identifier](http://spdx.org/licenses/) of one of the [supported licenses](#build-in-licenses). 
 
 ### Setting the license to use explicitly
 
@@ -98,11 +98,11 @@ headerLicense := Some(HeaderLicense.Custom(
 ))
 ```
 
-Note that you don't need to add comment markers like `//` or `/*`. The comment style is configured on a per file type basis and it explained in the [next section](#build-in-comment-styles).
+Note that you don't need to add comment markers like `//` or `/*`. The comment style is configured on a per file type basis (see [next section](#build-in-comment-styles)).
 
 ### Configuring comment styles
 
-Comment styles are configured on a per file type basis. The default is to apply C Style block comments to Scala and Java files. The build-in comment styles are defined in [CommentStyle](https://github.com/sbt/sbt-header/blob/master/src/main/scala/de/heikoseeberger/sbtheader/CommentStyle.scala):
+Comment styles are configured on a per file type basis. The default is to apply C Style block comments to Scala and Java files. No other comment styles are predefined. If you want to create comments for example for your XML files, you have to add the corresponding mapping manually (see below). The build-in comment styles are defined in [CommentStyle](https://github.com/sbt/sbt-header/blob/master/src/main/scala/de/heikoseeberger/sbtheader/CommentStyle.scala):
 
 |Name|Description|
 |----|-----------|
@@ -112,7 +112,7 @@ Comment styles are configured on a per file type basis. The default is to apply 
 |TwirlStyleComment|Twirl style comment (blocks starting with "@*" and ending with "*@")|
 |TwirlStyleBlockComment|Twirl style block comments (comment blocks with a frame made of "*")|
 
-To override the configuration for Scala/Java files or add a configuration to some other files type, use the `headerMapping` setting:
+To override the configuration for Scala/Java files or add a configuration for some other file type, use the `headerMapping` setting:
 
 ``` scala
 headersMappings := headerMapping.value + ("scala" -> CppStyleLineComment)
@@ -166,7 +166,7 @@ AutomateHeaderPlugin.automateFor(It, MultiJvm)
 ## Integration with other plugins
 
 This plugin by default only handles `managedSources` and `managedResources` in `Compile` and `Test`. For this reason you
-need to tell sbt-header when it should also add headers to additional files managed by other plugins.
+need to tell sbt-header if it should also add headers to additional files managed by other plugins.
 
 ### sbt-twirl / play projects
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Comment styles are configured on a per file type basis. The default is to apply 
 To override the configuration for Scala/Java files or add a configuration for some other file type, use the `headerMapping` setting:
 
 ``` scala
-headersMappings := headerMapping.value + ("scala" -> CppStyleLineComment)
+headersMappings := headerMapping.value + (HeaderFileType.scala -> HeaderCommentStyle.CppStyleLineComment)
 ```
 
 ### Excluding files
@@ -175,33 +175,31 @@ project), the Twirl templates have to be added to the sources handled by sbt-hea
 definition:
 
 ```scala
-import de.heikoseeberger.sbtheader.license.Apache2_0
+import de.heikoseeberger.sbtheader.FileType
 import play.twirl.sbt.Import.TwirlKeys
 
-headers := Map(
-  "html" -> Apache2_0("2015", "Heiko Seeberger", "@*")
-)
+headersMappings := headerMapping.value + (FileType("html") -> HeaderCommentStyle.TwirlStyleBlockComment)
 
 unmanagedSources.in(Compile, createHeaders) ++= sources.in(Compile, TwirlKeys.compileTemplates).value
 ```
 
-sbt-header supports two comment styles for Twirl templates. `@*` will produce simple twirl comments, while `@**` produce
-twirl block comments.
+sbt-header supports two comment styles for Twirl templates. `TwirlStyleBlockComment` will produce simple twirl block comments, while `TwirlStyleFramedBlockComment` will produce
+framed twirl comments.
 
-`@*` comment style:
+`TwirlStyleBlockComment` comment style:
 
 ```scala
 @*
- * This is a simple twirl comment
+ * This is a simple twirl block comment
  *@
 ```
 
-`@**` comment style:
+`TwirlStyleFramedBlockComment` comment style:
 
 ```scala
-@*********************************
- * This is a twirl block comment *
- ********************************@
+@**********************************
+ * This is a framed twirl comment *
+ **********************************@
 ```
 
 ### sbt-boilerplate


### PR DESCRIPTION
First draft of the documentation for the 2.0.0 release (fix for #79). I still need to work on the migration guide for users coming from 1.x version of the plugin.