### PR TITLE
Introduce FileType as new abstraction allowing to specify header lines

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,5 @@ platform:
 build_script:
   - sbt compile
 test_script:
-  - sbt checkHeaders
   - sbt test
   - sbt scripted

--- a/src/main/scala/de/heikoseeberger/sbtheader/FileType.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/FileType.scala
@@ -24,9 +24,9 @@ object FileType {
   def firstLinePattern(firstLinePattern: String): Regex =
     s"""($firstLinePattern(?:\n|(?:\r\n))+)((?:.|\n|(?:\r\n))*)""".r
 
-  val conf  = FileType("conf")
-  val java  = FileType("java")
-  val scala = FileType("scala")
-  val sh    = FileType("sh", Some(firstLinePattern("#!.*")))
-  val xml   = FileType("xml", Some(firstLinePattern("<\\?xml.*\\?>")))
+  val conf: FileType  = FileType("conf")
+  val java: FileType  = FileType("java")
+  val scala: FileType = FileType("scala")
+  val sh: FileType    = FileType("sh", Some(firstLinePattern("#!.*")))
+  val xml: FileType   = FileType("xml", Some(firstLinePattern("<\\?xml.*\\?>")))
 }

--- a/src/main/scala/de/heikoseeberger/sbtheader/FileType.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/FileType.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.heikoseeberger.sbtheader
+
+import scala.util.matching.Regex
+
+case class FileType(extension: String, firstLinePattern: Option[Regex] = None)
+
+object FileType {
+  def firstLinePattern(firstLinePattern: String): Regex =
+    s"""($firstLinePattern(?:\n|(?:\r\n))+)((?:.|\n|(?:\r\n))*)""".r
+
+  val conf  = FileType("conf")
+  val java  = FileType("java")
+  val scala = FileType("scala")
+  val sh    = FileType("sh", Some(firstLinePattern("#!.*")))
+  val xml   = FileType("xml", Some(firstLinePattern("<\\?xml.*\\?>")))
+}

--- a/src/main/scala/de/heikoseeberger/sbtheader/FileType.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/FileType.scala
@@ -18,7 +18,7 @@ package de.heikoseeberger.sbtheader
 
 import scala.util.matching.Regex
 
-case class FileType(extension: String, firstLinePattern: Option[Regex] = None)
+final case class FileType(extension: String, firstLinePattern: Option[Regex] = None)
 
 object FileType {
   def firstLinePattern(firstLinePattern: String): Regex =

--- a/src/main/scala/de/heikoseeberger/sbtheader/HeaderCreator.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/HeaderCreator.scala
@@ -18,31 +18,41 @@ package de.heikoseeberger.sbtheader
 
 import java.io.InputStream
 import sbt.Logger
-import scala.util.matching.Regex
 
 object HeaderCreator {
 
-  def apply(headerPattern: Regex,
-            headerText: String,
+  def apply(fileType: FileType,
+            commentStyle: CommentStyle,
+            license: License,
             log: Logger,
             input: InputStream): HeaderCreator =
-    new HeaderCreator(headerPattern, headerText, log, input)
+    new HeaderCreator(fileType, commentStyle, license, log, input)
 }
 
-final class HeaderCreator private (headerPattern: Regex,
-                                   headerText: String,
+final class HeaderCreator private (fileType: FileType,
+                                   commentStyle: CommentStyle,
+                                   license: License,
                                    log: Logger,
                                    input: InputStream) {
 
   private val shebangAndBody = """(#!.*(?:\n|(?:\r\n))+)((?:.|\n|(?:\r\n))*)""".r
   private val crlf           = """(?s)(?:.*)(\r\n)(?:.*)""".r
   private val cr             = """(?s)(?:.*)(\r)(?:.*)""".r
+  private val headerText     = commentStyle(license)
+  private val headerPattern  = commentStyle.pattern
 
-  private val (firstLine, text) =
-    scala.io.Source.fromInputStream(input).mkString match {
-      case shebangAndBody(s, b) => (s, b)
-      case other                => ("", other)
+  private val (firstLine, text) = {
+    val fileContent = scala.io.Source.fromInputStream(input).mkString
+    fileType.firstLinePattern match {
+      case Some(pattern) =>
+        fileContent match {
+          case pattern(first, rest) => (first, rest)
+          case other                => ("", other)
+        }
+      case _ => ("", fileContent)
     }
+  }
+
   log.debug(s"First line of file is:$newLine$firstLine")
   log.debug(s"Text of file is:$newLine$text")
 

--- a/src/main/scala/de/heikoseeberger/sbtheader/HeaderCreator.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/HeaderCreator.scala
@@ -35,10 +35,10 @@ final class HeaderCreator private (fileType: FileType,
                                    log: Logger,
                                    input: InputStream) {
 
-  private val crlf           = """(?s)(?:.*)(\r\n)(?:.*)""".r
-  private val cr             = """(?s)(?:.*)(\r)(?:.*)""".r
-  private val headerText     = commentStyle(license)
-  private val headerPattern  = commentStyle.pattern
+  private val crlf          = """(?s)(?:.*)(\r\n)(?:.*)""".r
+  private val cr            = """(?s)(?:.*)(\r)(?:.*)""".r
+  private val headerText    = commentStyle(license)
+  private val headerPattern = commentStyle.pattern
 
   private val (firstLine, text) = {
     val fileContent = scala.io.Source.fromInputStream(input).mkString

--- a/src/main/scala/de/heikoseeberger/sbtheader/HeaderCreator.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/HeaderCreator.scala
@@ -35,7 +35,6 @@ final class HeaderCreator private (fileType: FileType,
                                    log: Logger,
                                    input: InputStream) {
 
-  private val shebangAndBody = """(#!.*(?:\n|(?:\r\n))+)((?:.|\n|(?:\r\n))*)""".r
   private val crlf           = """(?s)(?:.*)(\r\n)(?:.*)""".r
   private val cr             = """(?s)(?:.*)(\r)(?:.*)""".r
   private val headerText     = commentStyle(license)

--- a/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala
@@ -21,7 +21,6 @@ import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.Files
 
 import de.heikoseeberger.sbtheader.CommentStyle.CStyleBlockComment
-import de.heikoseeberger.sbtheader.{ FileType => HeaderFileType }
 import sbt.Keys.{
   licenses,
   organizationName,
@@ -64,7 +63,7 @@ object HeaderPlugin extends AutoPlugin {
         )
     }
 
-    type FileType = HeaderFileType
+    val HeaderFileType = FileType
 
     val HeaderCommentStyle = CommentStyle
 

--- a/src/sbt-test/sbt-header/override-default-mappings/test.sbt
+++ b/src/sbt-test/sbt-header/override-default-mappings/test.sbt
@@ -1,5 +1,5 @@
 headerLicense := Some(HeaderLicense.ALv2("2015", "Heiko Seeberger"))
-headerMappings := headerMappings.value + ("scala" -> HeaderCommentStyle.CppStyleLineComment)
+headerMappings := headerMappings.value + (HeaderFileType.scala -> HeaderCommentStyle.CppStyleLineComment)
 
 val checkFileContents = taskKey[Unit]("Verify file contents match expected contents")
 

--- a/src/sbt-test/sbt-header/play-twirl/test.sbt
+++ b/src/sbt-test/sbt-header/play-twirl/test.sbt
@@ -1,7 +1,7 @@
 import play.twirl.sbt.Import.TwirlKeys
 
 headerLicense := Some(HeaderLicense.ALv2("2015", "Heiko Seeberger"))
-headerMappings := Map("html" -> HeaderCommentStyle.TwirlStyleFramedBlockComment)
+headerMappings := Map(HeaderFileType("html") -> HeaderCommentStyle.TwirlStyleFramedBlockComment)
 
 unmanagedSources.in(Compile, headerCreate) ++= sources.in(Compile, TwirlKeys.compileTemplates).value
 

--- a/src/test/scala/de/heikoseeberger/sbtheader/HeaderCreatorSpec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/HeaderCreatorSpec.scala
@@ -29,97 +29,111 @@ final class StubLogger extends Logger {
 
 final class HeaderCreatorSpec extends WordSpec with Matchers {
 
-  "CreatorHeader.createText" should {
-    "create a header with crlf and file crlf should produce file crlf" in {
-      val fileContent = "this is a file with lf endings\r\n"
-      val header      = "#this is a header text with lf endings\r\n"
+  "HeaderCreator" when {
 
-      HeaderCreator(
-        HashLineComment.pattern,
-        header,
-        new StubLogger,
-        new ByteArrayInputStream(fileContent.getBytes)
-      ).createText shouldBe Some(header + fileContent)
+    "given a file with crlf line endings" should {
+
+      val fileContent = "this is a file with crlf endings\r\n"
+
+      "produce a file with crlf line endings from a header with crlf line endings" in {
+        val header = "#this is a header text with lf endings\r\n"
+
+        HeaderCreator(
+          HashLineComment.pattern,
+          header,
+          new StubLogger,
+          new ByteArrayInputStream(fileContent.getBytes)
+        ).createText shouldBe Some(header + fileContent)
+      }
+
+      "produce a file with crlf line endings from a header with lf line endings" in {
+        val header         = "#this is a header text with lf endings\n"
+        val expectedResult = Some(header.replace("\n", "\r\n") + fileContent)
+
+        HeaderCreator(
+          HashLineComment.pattern,
+          header,
+          new StubLogger,
+          new ByteArrayInputStream(fileContent.getBytes)
+        ).createText shouldBe expectedResult
+      }
     }
 
-    "create a header with lf and file lf should produce file lf" in {
+    "given a file with lf line endings" should {
+
       val fileContent = "this is a file with lf endings\n"
-      val header      = "#this is a header text with lf endings\n"
 
-      HeaderCreator(
-        HashLineComment.pattern,
-        header,
-        new StubLogger,
-        new ByteArrayInputStream(fileContent.getBytes)
-      ).createText shouldBe Some(header + fileContent)
+      "produce a file with lf line endings from a header with lf line endings" in {
+        val header = "#this is a header text with lf endings\n"
+
+        HeaderCreator(
+          HashLineComment.pattern,
+          header,
+          new StubLogger,
+          new ByteArrayInputStream(fileContent.getBytes)
+        ).createText shouldBe Some(header + fileContent)
+      }
+
+      "produce a file with lf line endings from a header with crlf line endings" in {
+        val header         = "#this is a header text with crlf endings\r\n"
+        val expectedResult = Some(header.replace("\r\n", "\n") + fileContent)
+
+        HeaderCreator(
+          HashLineComment.pattern,
+          header,
+          new StubLogger,
+          new ByteArrayInputStream(fileContent.getBytes)
+        ).createText shouldBe expectedResult
+      }
     }
 
-    "create a header with lf and file crlf should produce file crlf" in {
-      val fileContent    = "this is a file with crlf endings\r\n"
-      val header         = "#this is a header text with lf endings\n"
-      val expectedResult = Some(header.replace("\n", "\r\n") + fileContent)
+    "given a file with cr line endings" should {
+      "produce a file with cr line endings from a header with crlf line endings" in {
+        val fileContent    = "this is a file with cr endings\r"
+        val header         = "#this is a header text with crlf endings\r\n"
+        val expectedResult = Some(header.replace("\r\n", "\r") + fileContent)
 
-      HeaderCreator(
-        HashLineComment.pattern,
-        header,
-        new StubLogger,
-        new ByteArrayInputStream(fileContent.getBytes)
-      ).createText shouldBe expectedResult
+        HeaderCreator(
+          HashLineComment.pattern,
+          header,
+          new StubLogger,
+          new ByteArrayInputStream(fileContent.getBytes)
+        ).createText shouldBe expectedResult
+      }
     }
 
-    "create a header with crlf and file lf should produce file lf" in {
-      val fileContent    = "this is a file with lf endings\n"
-      val header         = "#this is a header text with crlf endings\r\n"
-      val expectedResult = Some(header.replace("\r\n", "\n") + fileContent)
+    "given a header with some line breaks" should {
 
-      HeaderCreator(
-        HashLineComment.pattern,
-        header,
-        new StubLogger,
-        new ByteArrayInputStream(fileContent.getBytes)
-      ).createText shouldBe expectedResult
-    }
+      "add as many new lines to output" in {
+        val fileContent = "this is a file with lf endings\n" +
+          "this is a file with lf endings\n" +
+          "this is a file with lf endings\n"
+        val header         = "#this is a header text with multiple lf endings\n\n\n\n"
+        val expectedResult = Some(header + fileContent)
 
-    "create a header with crlf and file cr should produce file cr" in {
-      val fileContent    = "this is a file with cr endings\r"
-      val header         = "#this is a header text with crlf endings\r\n"
-      val expectedResult = Some(header.replace("\r\n", "\r") + fileContent)
-
-      HeaderCreator(
-        HashLineComment.pattern,
-        header,
-        new StubLogger,
-        new ByteArrayInputStream(fileContent.getBytes)
-      ).createText shouldBe expectedResult
-    }
-
-    "it should add as many new lines exists in header" in {
-      val fileContent = "this is a file with lf endings\n" +
-        "this is a file with lf endings\n" +
-        "this is a file with lf endings\n"
-      val header         = "#this is a header text with multiple lf endings\n\n\n\n"
-      val expectedResult = Some(header + fileContent)
-
-      HeaderCreator(
-        HashLineComment.pattern,
-        header,
-        new StubLogger,
-        new ByteArrayInputStream(fileContent.getBytes)
-      ).createText shouldBe expectedResult
+        HeaderCreator(
+          HashLineComment.pattern,
+          header,
+          new StubLogger,
+          new ByteArrayInputStream(fileContent.getBytes)
+        ).createText shouldBe expectedResult
+      }
     }
 
     //Due to java bug http://bugs.java.com/bugdatabase/view_bug.do?bug_id=8028387
-    "it should work with large files" in {
-      val fileContent    = "this is a file with lf endings\n" * 50
-      val header         = "#this is a header text with multiple lf endings\n"
-      val expectedResult = Some(header + fileContent)
+    "given a large file" should {
+      "work" in {
+        val fileContent    = "this is a file with lf endings\n" * 50
+        val header         = "#this is a header text with multiple lf endings\n"
+        val expectedResult = Some(header + fileContent)
 
-      HeaderCreator(
-        HashLineComment.pattern,
-        header,
-        new StubLogger,
-        new ByteArrayInputStream(fileContent.getBytes)
-      ).createText shouldBe expectedResult
+        HeaderCreator(
+          HashLineComment.pattern,
+          header,
+          new StubLogger,
+          new ByteArrayInputStream(fileContent.getBytes)
+        ).createText shouldBe expectedResult
+      }
     }
   }
 }

--- a/src/test/scala/de/heikoseeberger/sbtheader/HeaderCreatorSpec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/HeaderCreatorSpec.scala
@@ -38,24 +38,14 @@ final class HeaderCreatorSpec extends WordSpec with Matchers {
       "produce a file with crlf line endings from a header with crlf line endings" in {
         val header = "#this is a header text with lf endings\r\n"
 
-        HeaderCreator(
-          HashLineComment.pattern,
-          header,
-          new StubLogger,
-          new ByteArrayInputStream(fileContent.getBytes)
-        ).createText shouldBe Some(header + fileContent)
+        createHeader(fileContent, header) shouldBe Some(header + fileContent)
       }
 
       "produce a file with crlf line endings from a header with lf line endings" in {
         val header         = "#this is a header text with lf endings\n"
         val expectedResult = Some(header.replace("\n", "\r\n") + fileContent)
 
-        HeaderCreator(
-          HashLineComment.pattern,
-          header,
-          new StubLogger,
-          new ByteArrayInputStream(fileContent.getBytes)
-        ).createText shouldBe expectedResult
+        createHeader(fileContent, header) shouldBe expectedResult
       }
     }
 
@@ -66,24 +56,14 @@ final class HeaderCreatorSpec extends WordSpec with Matchers {
       "produce a file with lf line endings from a header with lf line endings" in {
         val header = "#this is a header text with lf endings\n"
 
-        HeaderCreator(
-          HashLineComment.pattern,
-          header,
-          new StubLogger,
-          new ByteArrayInputStream(fileContent.getBytes)
-        ).createText shouldBe Some(header + fileContent)
+        createHeader(fileContent, header) shouldBe Some(header + fileContent)
       }
 
       "produce a file with lf line endings from a header with crlf line endings" in {
         val header         = "#this is a header text with crlf endings\r\n"
         val expectedResult = Some(header.replace("\r\n", "\n") + fileContent)
 
-        HeaderCreator(
-          HashLineComment.pattern,
-          header,
-          new StubLogger,
-          new ByteArrayInputStream(fileContent.getBytes)
-        ).createText shouldBe expectedResult
+        createHeader(fileContent, header) shouldBe expectedResult
       }
     }
 
@@ -93,12 +73,7 @@ final class HeaderCreatorSpec extends WordSpec with Matchers {
         val header         = "#this is a header text with crlf endings\r\n"
         val expectedResult = Some(header.replace("\r\n", "\r") + fileContent)
 
-        HeaderCreator(
-          HashLineComment.pattern,
-          header,
-          new StubLogger,
-          new ByteArrayInputStream(fileContent.getBytes)
-        ).createText shouldBe expectedResult
+        createHeader(fileContent, header) shouldBe expectedResult
       }
     }
 
@@ -111,12 +86,7 @@ final class HeaderCreatorSpec extends WordSpec with Matchers {
         val header         = "#this is a header text with multiple lf endings\n\n\n\n"
         val expectedResult = Some(header + fileContent)
 
-        HeaderCreator(
-          HashLineComment.pattern,
-          header,
-          new StubLogger,
-          new ByteArrayInputStream(fileContent.getBytes)
-        ).createText shouldBe expectedResult
+        createHeader(fileContent, header) shouldBe expectedResult
       }
     }
 
@@ -127,13 +97,16 @@ final class HeaderCreatorSpec extends WordSpec with Matchers {
         val header         = "#this is a header text with multiple lf endings\n"
         val expectedResult = Some(header + fileContent)
 
-        HeaderCreator(
-          HashLineComment.pattern,
-          header,
-          new StubLogger,
-          new ByteArrayInputStream(fileContent.getBytes)
-        ).createText shouldBe expectedResult
+        createHeader(fileContent, header) shouldBe expectedResult
       }
     }
   }
+
+  private def createHeader(fileContent: String, header: String) =
+    HeaderCreator(
+      HashLineComment.pattern,
+      header,
+      new StubLogger,
+      new ByteArrayInputStream(fileContent.getBytes)
+    ).createText
 }

--- a/src/test/scala/de/heikoseeberger/sbtheader/HeaderCreatorSpec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/HeaderCreatorSpec.scala
@@ -17,10 +17,13 @@
 package de.heikoseeberger.sbtheader
 
 import java.io.ByteArrayInputStream
+
 import org.scalatest.{ Matchers, WordSpec }
 import sbt.Logger
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.HeaderCommentStyle.HashLineComment
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.HeaderLicense.Custom
+
+import scala.util.matching.Regex
 
 final class StubLogger extends Logger {
   override def log(level: sbt.Level.Value, message: => String) = ()
@@ -120,16 +123,18 @@ final class HeaderCreatorSpec extends WordSpec with Matchers {
 
     "given a file with shebang" should {
 
-      val shebang     = "#!/bin/bash" + newLine
-      val script      = "echo Hello World"
+      val shebang = "#!/bin/bash" + newLine
+      val script =
+        """|echo Hello World
+           |exit 0
+           |""".stripMargin
       val licenseText = "Copyright 2015 Heiko Seeberger"
       val header      = HashLineComment(licenseText)
 
       "preserve shebang and add header when header is missing" in {
-        val fileContent    = shebang + script
-        val expectedResult = Some(shebang + header + script)
+        val fileContent = shebang + script
 
-        createHeader(fileContent, licenseText) shouldBe expectedResult
+        createHeader(fileContent, licenseText) shouldBe Some(shebang + header + script)
       }
 
       "not touch file when header is present" in {
@@ -154,11 +159,11 @@ final class HeaderCreatorSpec extends WordSpec with Matchers {
            |  <artifactId>my-artifact</artifactId>
            |  <version>1.1-SNAPTHO</version>
            |</project>
-        """.stripMargin
+           |""".stripMargin
       val licenseText = "Copyright 2015 Heiko Seeberger"
       val header      = HashLineComment(licenseText)
 
-      "preserve shebang and add header when header is missing" in {
+      "preserve XML declaration and add header when header is missing" in {
         val fileContent    = xmlDeclaration + xmlBody
         val expectedResult = Some(xmlDeclaration + header + xmlBody)
 

--- a/src/test/scala/de/heikoseeberger/sbtheader/HeaderCreatorSpec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/HeaderCreatorSpec.scala
@@ -100,6 +100,26 @@ final class HeaderCreatorSpec extends WordSpec with Matchers {
         createHeader(fileContent, header) shouldBe expectedResult
       }
     }
+
+    "given a file with shebang" should {
+
+      val shebang = "#!/bin/bash" + newLine
+      val script  = "echo Hello World"
+      val header  = HashLineComment("Copyright 2015 Heiko Seeberger")
+
+      "preserve shebang and add header when header is missing" in {
+        val fileContent    = shebang + script
+        val expectedResult = Some(shebang + header + script)
+
+        createHeader(fileContent, header) shouldBe expectedResult
+      }
+
+      "not touch file when header is present" in {
+        val fileContent = shebang + header + script
+
+        createHeader(fileContent, header) shouldBe None
+      }
+    }
   }
 
   private def createHeader(fileContent: String, header: String) =

--- a/src/test/scala/de/heikoseeberger/sbtheader/HeaderCreatorSpec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/HeaderCreatorSpec.scala
@@ -138,11 +138,38 @@ final class HeaderCreatorSpec extends WordSpec with Matchers {
         createHeader(fileContent, licenseText) shouldBe None
       }
     }
+
+    "given an XML file with XML declaration" should {
+
+      val xmlDeclaration = """<?xml version="1.0" encoding="UTF-8"?>""" + newLine
+      val xmlBody =
+        """|<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+           |  <parent>
+           |    <groupId>my.group</groupId>
+           |    <artifactId>my-parent</artifactId>
+           |    <version>42</version>
+           |  </parent>
+           |  <modelVersion>4.0.0</modelVersion>
+           |  <groupId>my.group</groupId>
+           |  <artifactId>my-artifact</artifactId>
+           |  <version>1.1-SNAPTHO</version>
+           |</project>
+        """.stripMargin
+      val licenseText = "Copyright 2015 Heiko Seeberger"
+      val header      = HashLineComment(licenseText)
+
+      "preserve shebang and add header when header is missing" in {
+        val fileContent    = xmlDeclaration + xmlBody
+        val expectedResult = Some(xmlDeclaration + header + xmlBody)
+
+        createHeader(fileContent, licenseText, FileType.xml) shouldBe expectedResult
+      }
+    }
   }
 
-  private def createHeader(fileContent: String, header: String) =
+  private def createHeader(fileContent: String, header: String, fileType: FileType = FileType.sh) =
     HeaderCreator(
-      FileType.sh,
+      fileType,
       HashLineComment,
       Custom(header),
       new StubLogger,


### PR DESCRIPTION
Fix for #101 and preparation for #90.

This introduces `FileType` as new abstraction. A `FileType` defines a file extension (e.g. `scala`) and an optional `Regex` matching a first line (for example a shebang line). If the `HeaderCreator` encounters a `FileType` with a first line matcher, it will preserve the first line, if one is found. This way we decouple first line detection from `HeaderCreator` at the cost of a slightly more verbose definition of `headerMappings`:

Before:

```scala
headerMappings := Map (
  "scala" -> CStyleCommentBlock,
  "java" -> CStyleCommentBlock
)
```

After:

```scala
headerMappings := Map (
  HeaderFileType.scala -> CStyleCommentBlock,
  HeaderFileType.java -> CStyleCommentBlock
)
```