### PR TITLE
WIP: Don't merge - SBT cross build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,23 @@
 language: scala
 
 scala:
+  - 2.10.6
   - 2.12.3
 
 jdk:
   - oraclejdk8
 
+env:
+  matrix:
+    - TRAVIS_SBT_VERSION=1.0.0
+    - TRAVIS_SBT_VERSION=0.13.16
+
 script:
-  - sbt test
-  - sbt scripted
+  - sbt ^^$TRAVIS_SBT_VERSION test scripted
+
+matrix:
+  exclude:
+    - scala: 2.10.6
+      env: TRAVIS_SBT_VERSION=1.0.0
+    - scala: 2.12.3
+      env: TRAVIS_SBT_VERSION=0.13.16

--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,8 @@ lazy val commonSettings =
       s"[$project]> "
     },
     sbtPlugin := true,
-    publishMavenStyle := false
+    publishMavenStyle := false,
+    crossSbtVersions := Vector("1.0.0", "0.13.16")
 )
 
 lazy val gitSettings =

--- a/build.sbt
+++ b/build.sbt
@@ -45,9 +45,14 @@ lazy val commonSettings =
       "-unchecked",
       "-deprecation",
       "-language:_",
-      "-target:jvm-1.8",
       "-encoding", "UTF-8"
     ),
+    scalacOptions ++= {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, n)) if n < 12 => Seq("-target:jvm-1.7")
+        case _                      => Nil
+      }
+    },
     unmanagedSourceDirectories.in(Compile) := Seq(scalaSource.in(Compile).value),
     unmanagedSourceDirectories.in(Test) := Seq(scalaSource.in(Test).value),
     shellPrompt in ThisBuild := { state =>


### PR DESCRIPTION
Initial work to add support for SBT 1.0. At the moment the scripted tests fail when run with 1.0.0-RC3 with following output:

```
[info] Error during sbt execution: Could not finder sbt launch configuration.  Searched classpath for:
[info]  /sbt.boot.propertiesUnspecified
[info]  /sbt/sbt.boot.propertiesUnspecified
[info]  /sbt.boot.properties
[info]  /sbt/sbt.boot.properties
```

When launching SBT 1.0.0-RC3 succeeds from each of the scripted test projects (except the Play! one).

In order to be able to test the Play! setup we need new versions of the its plugins.