### PR TITLE
Add IdentityCommentCreator that does not place any spacial characters.

### DIFF
--- a/src/main/scala/de/heikoseeberger/sbtheader/CommentStyle.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/CommentStyle.scala
@@ -130,6 +130,5 @@ final class CommentBlockCreator(blockPrefix: String, linePrefix: String, blockSu
 }
 
 object NoneCommentCreator extends CommentCreator {
-  override def apply(text: String): String =
-    text.lines.mkString(newLine)
+  override def apply(text: String): String = text
 }

--- a/src/main/scala/de/heikoseeberger/sbtheader/CommentStyle.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/CommentStyle.scala
@@ -128,3 +128,8 @@ final class CommentBlockCreator(blockPrefix: String, linePrefix: String, blockSu
   def apply(text: String): String =
     blockPrefix + newLine + lineCommentCreator(text) + newLine + blockSuffix
 }
+
+object NoneCommentCreator extends CommentCreator {
+  override def apply(text: String): String =
+    text.lines.mkString(newLine)
+}

--- a/src/main/scala/de/heikoseeberger/sbtheader/CommentStyle.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/CommentStyle.scala
@@ -129,6 +129,6 @@ final class CommentBlockCreator(blockPrefix: String, linePrefix: String, blockSu
     blockPrefix + newLine + lineCommentCreator(text) + newLine + blockSuffix
 }
 
-object NoneCommentCreator extends CommentCreator {
-  override def apply(text: String): String = text
+object IdentityCommentCreator extends CommentCreator {
+  override def apply(text: String) = text
 }

--- a/src/test/scala/de/heikoseeberger/sbtheader/CommentStyleSpec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/CommentStyleSpec.scala
@@ -396,4 +396,29 @@ class CommentStyleSpec extends WordSpec with Matchers {
       XmlStyleBlockComment.pattern.unapplySeq(header + body) shouldBe Some(List(header, body))
     }
   }
+
+  "NoneCommentCreator" should {
+
+    "not create any prefix in the header" in {
+      val expected =
+        s"""$licenseText""".stripMargin
+
+      NoneCommentCreator(licenseText) shouldBe expected
+    }
+
+    "create the same license text with new line characters" in {
+
+      val severalLinesLicense =
+        """
+          | Some random license text
+          | with several new line
+          | characters.
+        """.stripMargin
+
+      val expected = s"""$severalLinesLicense""".stripMargin
+
+      NoneCommentCreator(severalLinesLicense) shouldBe expected
+    }
+  }
+
 }

--- a/src/test/scala/de/heikoseeberger/sbtheader/CommentStyleSpec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/CommentStyleSpec.scala
@@ -397,13 +397,13 @@ class CommentStyleSpec extends WordSpec with Matchers {
     }
   }
 
-  "NoneCommentCreator" should {
+  "IdentityCommentCreator" should {
 
     "not create any prefix in the header" in {
       val expected =
         s"""$licenseText""".stripMargin
 
-      NoneCommentCreator(licenseText) shouldBe expected
+      IdentityCommentCreator(licenseText) shouldBe expected
     }
 
     "create the same license text with new line characters" in {
@@ -417,7 +417,7 @@ class CommentStyleSpec extends WordSpec with Matchers {
 
       val expected = s"""$severalLinesLicense""".stripMargin
 
-      NoneCommentCreator(severalLinesLicense) shouldBe expected
+      IdentityCommentCreator(severalLinesLicense) shouldBe expected
     }
   }
 


### PR DESCRIPTION
Some repositories like Scala use special ASCII drawings where even special comment symbols are a part of art.

For example: 

```
/*                     __                                               *\
**     ________ ___   / /  ___     Scala API                            **
**    / __/ __// _ | / /  / _ |    (c) 2003-2013, LAMP/EPFL             **
**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
** /____/\___/_/ |_/____/_/ | |                                         **
**                          |/                                          **
\*   
```

So I decided to add special CommentStyle which does not add any special character and instead just places the text that was accepted.