### PR TITLE
Make CommentStyle configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,16 +105,16 @@ Comment styles are configured on a per file type basis. The default is to apply 
 
 |Name|Description|
 |----|-----------|
-|CStyleBlockComment|C style block comments (blocks starting with "/\*" and ending with "\*/")|
-|CppStyleLineComment|C++ style line comments (lines prefixed with "//")|
-|HashLineComment|Hash line comments (lines prefixed with "#")|
-|TwirlStyleComment|Twirl style comment (blocks starting with "@\*" and ending with "\*@")|
-|TwirlStyleBlockComment|Twirl style block comments (comment blocks with a frame made of "*")|
+|cStyleBlockComment|C style block comments (blocks starting with "/\*" and ending with "\*/")|
+|cppStyleLineComment|C++ style line comments (lines prefixed with "//")|
+|hashLineComment|Hash line comments (lines prefixed with "#")|
+|twirlStyleComment|Twirl style comment (blocks starting with "@\*" and ending with "\*@")|
+|twirlStyleBlockComment|Twirl style block comments (comment blocks with a frame made of "*")|
 
 To override the configuration for Scala/Java files or add a configuration for some other file type, use the `headerMapping` setting:
 
 ``` scala
-headerMappings := headerMappings.value + (HeaderFileType.scala -> HeaderCommentStyle.CppStyleLineComment)
+headerMappings := headerMappings.value + (HeaderFileType.scala -> HeaderCommentStyle.cppStyleLineComment)
 ```
 
 ### Excluding files
@@ -177,15 +177,15 @@ definition:
 import de.heikoseeberger.sbtheader.FileType
 import play.twirl.sbt.Import.TwirlKeys
 
-headerMappings := headerMappings.value + (FileType("html") -> HeaderCommentStyle.TwirlStyleBlockComment)
+headerMappings := headerMappings.value + (FileType("html") -> HeaderCommentStyle.twirlStyleBlockComment)
 
 unmanagedSources.in(Compile, headerCreate) ++= sources.in(Compile, TwirlKeys.compileTemplates).value
 ```
 
-sbt-header supports two comment styles for Twirl templates. `TwirlStyleBlockComment` will produce simple twirl block comments, while `TwirlStyleFramedBlockComment` will produce
+sbt-header supports two comment styles for Twirl templates. `twirlStyleBlockComment` will produce simple twirl block comments, while `twirlStyleFramedBlockComment` will produce
 framed twirl comments.
 
-`TwirlStyleBlockComment` comment style:
+`twirlStyleBlockComment` comment style:
 
 ```scala
 @*
@@ -193,7 +193,7 @@ framed twirl comments.
  *@
 ```
 
-`TwirlStyleFramedBlockComment` comment style:
+`twirlStyleFramedBlockComment` comment style:
 
 ```scala
 @**********************************

--- a/src/main/scala/de/heikoseeberger/sbtheader/CommentStyle.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/CommentStyle.scala
@@ -25,11 +25,7 @@ import scala.util.matching.Regex
 /**
   * Representation of the different comment styles supported by this plugin.
   */
-sealed trait CommentStyle {
-
-  def pattern: Regex
-
-  def commentCreator: CommentCreator
+case class CommentStyle(commentCreator: CommentCreator, pattern: Regex) {
 
   def apply(licenseText: String): String =
     commentCreator(licenseText) + newLine + newLine
@@ -44,47 +40,22 @@ sealed trait CommentCreator {
 
 object CommentStyle {
 
-  final case object CStyleBlockComment extends CommentStyle {
+  val CStyleBlockComment = CommentStyle(new CommentBlockCreator("/*", " *", " */"),
+                                        commentBetween("""/\*+""", "*", """\*/"""))
 
-    override val commentCreator = new CommentBlockCreator("/*", " *", " */")
+  val CppStyleLineComment = CommentStyle(new LineCommentCreator("//"), commentStartingWith("//"))
 
-    override val pattern = commentBetween("""/\*+""", "*", """\*/""")
-  }
+  val HashLineComment = CommentStyle(new LineCommentCreator("#"), commentStartingWith("#"))
 
-  case object CppStyleLineComment extends CommentStyle {
+  val TwirlStyleBlockComment = CommentStyle(new CommentBlockCreator("@*", " *", " *@"),
+                                            commentBetween("""@\*""", "*", """\*@"""))
 
-    override val commentCreator = new LineCommentCreator("//")
+  val TwirlStyleFramedBlockComment =
+    CommentStyle(TwirlStyleFramedBlockCommentCreator, commentBetween("""@\*+""", "*", """\*@"""))
 
-    override val pattern = commentStartingWith("//")
-  }
+  val XmlStyleBlockComment =
+    CommentStyle(new CommentBlockCreator("<!--", "  ", "-->"), commentBetween("<!--", "  ", "-->"))
 
-  case object HashLineComment extends CommentStyle {
-
-    override val commentCreator = new LineCommentCreator("#")
-
-    override val pattern = commentStartingWith("#")
-  }
-
-  case object TwirlStyleBlockComment extends CommentStyle {
-
-    override val commentCreator = new CommentBlockCreator("@*", " *", " *@")
-
-    override val pattern = commentBetween("""@\*""", "*", """\*@""")
-  }
-
-  case object TwirlStyleFramedBlockComment extends CommentStyle {
-
-    override val commentCreator = TwirlStyleFramedBlockCommentCreator
-
-    override val pattern = commentBetween("""@\*+""", "*", """\*@""")
-  }
-
-  case object XmlStyleBlockComment extends CommentStyle {
-
-    override val commentCreator = new CommentBlockCreator("<!--", "  ", "-->")
-
-    override val pattern = commentBetween("<!--", "  ", "-->")
-  }
 }
 
 object TwirlStyleFramedBlockCommentCreator extends CommentCreator {

--- a/src/main/scala/de/heikoseeberger/sbtheader/CommentStyle.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/CommentStyle.scala
@@ -40,20 +40,20 @@ sealed trait CommentCreator {
 
 object CommentStyle {
 
-  val CStyleBlockComment = CommentStyle(new CommentBlockCreator("/*", " *", " */"),
+  val cStyleBlockComment = CommentStyle(new CommentBlockCreator("/*", " *", " */"),
                                         commentBetween("""/\*+""", "*", """\*/"""))
 
-  val CppStyleLineComment = CommentStyle(new LineCommentCreator("//"), commentStartingWith("//"))
+  val cppStyleLineComment = CommentStyle(new LineCommentCreator("//"), commentStartingWith("//"))
 
-  val HashLineComment = CommentStyle(new LineCommentCreator("#"), commentStartingWith("#"))
+  val hashLineComment = CommentStyle(new LineCommentCreator("#"), commentStartingWith("#"))
 
-  val TwirlStyleBlockComment = CommentStyle(new CommentBlockCreator("@*", " *", " *@"),
+  val twirlStyleBlockComment = CommentStyle(new CommentBlockCreator("@*", " *", " *@"),
                                             commentBetween("""@\*""", "*", """\*@"""))
 
-  val TwirlStyleFramedBlockComment =
+  val twirlStyleFramedBlockComment =
     CommentStyle(TwirlStyleFramedBlockCommentCreator, commentBetween("""@\*+""", "*", """\*@"""))
 
-  val XmlStyleBlockComment =
+  val xmlStyleBlockComment =
     CommentStyle(new CommentBlockCreator("<!--", "  ", "-->"), commentBetween("<!--", "  ", "-->"))
 
 }

--- a/src/main/scala/de/heikoseeberger/sbtheader/CommentStyle.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/CommentStyle.scala
@@ -25,7 +25,7 @@ import scala.util.matching.Regex
 /**
   * Representation of the different comment styles supported by this plugin.
   */
-case class CommentStyle(commentCreator: CommentCreator, pattern: Regex) {
+final case class CommentStyle(commentCreator: CommentCreator, pattern: Regex) {
 
   def apply(licenseText: String): String =
     commentCreator(licenseText) + newLine + newLine

--- a/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala
@@ -16,7 +16,7 @@
 
 package de.heikoseeberger.sbtheader
 
-import de.heikoseeberger.sbtheader.CommentStyle.CStyleBlockComment
+import de.heikoseeberger.sbtheader.CommentStyle.cStyleBlockComment
 import java.io.File
 import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.Files
@@ -113,8 +113,8 @@ object HeaderPlugin extends AutoPlugin {
   private def notToBeScopedSettings =
     Vector(
       headerMappings := Map(
-        FileType.scala -> CStyleBlockComment,
-        FileType.java  -> CStyleBlockComment
+        FileType.scala -> cStyleBlockComment,
+        FileType.java  -> cStyleBlockComment
       ),
       headerLicense := LicenseDetection(licenses.value.toList,
                                         organizationName.value,

--- a/src/sbt-test/sbt-header/override-default-mappings/test.sbt
+++ b/src/sbt-test/sbt-header/override-default-mappings/test.sbt
@@ -1,5 +1,5 @@
 headerLicense := Some(HeaderLicense.ALv2("2015", "Heiko Seeberger"))
-headerMappings := headerMappings.value + (HeaderFileType.scala -> HeaderCommentStyle.CppStyleLineComment)
+headerMappings := headerMappings.value + (HeaderFileType.scala -> HeaderCommentStyle.cppStyleLineComment)
 
 val checkFileContents = taskKey[Unit]("Verify file contents match expected contents")
 

--- a/src/sbt-test/sbt-header/xml/test.sbt
+++ b/src/sbt-test/sbt-header/xml/test.sbt
@@ -1,6 +1,6 @@
 headerLicense := Some(HeaderLicense.ALv2("2015", "Heiko Seeberger"))
 
-headerMappings := Map(HeaderFileType.xml -> HeaderCommentStyle.XmlStyleBlockComment)
+headerMappings := Map(HeaderFileType.xml -> HeaderCommentStyle.xmlStyleBlockComment)
 
 val checkFileContents = taskKey[Unit]("Verify file contents match expected contents")
 

--- a/src/test/scala/de/heikoseeberger/sbtheader/CommentStyleSpec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/CommentStyleSpec.scala
@@ -33,15 +33,15 @@ class CommentStyleSpec extends WordSpec with Matchers {
             |
             |""".stripMargin
 
-      CStyleBlockComment(licenseText) shouldBe expected
+      cStyleBlockComment(licenseText) shouldBe expected
     }
 
     "not match a singleline comment without a trailing new line" in {
-      CStyleBlockComment.pattern.unapplySeq("/* comment */") shouldBe None
+      cStyleBlockComment.pattern.unapplySeq("/* comment */") shouldBe None
     }
 
     "not match a multiline comment without a trailing new line" in {
-      CStyleBlockComment.pattern.unapplySeq(
+      cStyleBlockComment.pattern.unapplySeq(
         """|/*
            | * comment/1
            | * comment/2
@@ -53,7 +53,7 @@ class CommentStyleSpec extends WordSpec with Matchers {
       val header = """|/* comment */
                       |
                       |""".stripMargin
-      CStyleBlockComment.pattern.unapplySeq(header) shouldBe Some(List(header, ""))
+      cStyleBlockComment.pattern.unapplySeq(header) shouldBe Some(List(header, ""))
     }
 
     "match a comment with a trailing new line followed by a body" in {
@@ -66,7 +66,7 @@ class CommentStyleSpec extends WordSpec with Matchers {
                       |  val bar = "bar"
                       |}
                       |""".stripMargin
-      CStyleBlockComment.pattern.unapplySeq(header + body) shouldBe Some(List(header, body))
+      cStyleBlockComment.pattern.unapplySeq(header + body) shouldBe Some(List(header, body))
     }
 
     "match a comment with a trailing new line followed by a body with a ScalaDoc comment" in {
@@ -82,7 +82,7 @@ class CommentStyleSpec extends WordSpec with Matchers {
                       |  val bar = "bar"
                       |}
                       |""".stripMargin
-      CStyleBlockComment.pattern.unapplySeq(header + body) shouldBe Some(List(header, body))
+      cStyleBlockComment.pattern.unapplySeq(header + body) shouldBe Some(List(header, body))
     }
 
     "match a left indented header with a trailing new line followed by a body with a ScalaDoc comment" in {
@@ -98,7 +98,7 @@ class CommentStyleSpec extends WordSpec with Matchers {
                       |  val bar = "bar"
                       |}
                       |""".stripMargin
-      CStyleBlockComment.pattern.unapplySeq(header + body) shouldBe Some(List(header, body))
+      cStyleBlockComment.pattern.unapplySeq(header + body) shouldBe Some(List(header, body))
     }
   }
 
@@ -110,15 +110,15 @@ class CommentStyleSpec extends WordSpec with Matchers {
             |
             |""".stripMargin
 
-      CppStyleLineComment(licenseText) shouldBe expected
+      cppStyleLineComment(licenseText) shouldBe expected
     }
 
     "not match a singleline comment without trailing new lines" in {
-      CppStyleLineComment.pattern.unapplySeq("// comment") shouldBe None
+      cppStyleLineComment.pattern.unapplySeq("// comment") shouldBe None
     }
 
     "not match a multiline block comment with a single trailing new line" in {
-      CppStyleLineComment.pattern.unapplySeq(
+      cppStyleLineComment.pattern.unapplySeq(
         """|// comment/1
            |// comment/2
            |""".stripMargin
@@ -130,7 +130,7 @@ class CommentStyleSpec extends WordSpec with Matchers {
                       |
                       |
                       |""".stripMargin
-      CppStyleLineComment.pattern.unapplySeq(header) shouldBe Some(List(header, ""))
+      cppStyleLineComment.pattern.unapplySeq(header) shouldBe Some(List(header, ""))
     }
 
     "match a comment with trailing new lines followed by a body" in {
@@ -141,7 +141,7 @@ class CommentStyleSpec extends WordSpec with Matchers {
       val body   = """|def foo(bar):
                       |    print(bar)
                       |""".stripMargin
-      CppStyleLineComment.pattern.unapplySeq(header + body) shouldBe Some(List(header, body))
+      cppStyleLineComment.pattern.unapplySeq(header + body) shouldBe Some(List(header, body))
     }
   }
 
@@ -153,15 +153,15 @@ class CommentStyleSpec extends WordSpec with Matchers {
             |
             |""".stripMargin
 
-      HashLineComment(licenseText) shouldBe expected
+      hashLineComment(licenseText) shouldBe expected
     }
 
     "not match a singleline comment without trailing new lines" in {
-      HashLineComment.pattern.unapplySeq("# comment") shouldBe None
+      hashLineComment.pattern.unapplySeq("# comment") shouldBe None
     }
 
     "not match a multiline block comment with a single trailing new line" in {
-      HashLineComment.pattern.unapplySeq(
+      hashLineComment.pattern.unapplySeq(
         """|# comment/1
            |# comment/2
            |""".stripMargin
@@ -173,7 +173,7 @@ class CommentStyleSpec extends WordSpec with Matchers {
                       |
                       |
                       |""".stripMargin
-      HashLineComment.pattern.unapplySeq(header) shouldBe Some(List(header, ""))
+      hashLineComment.pattern.unapplySeq(header) shouldBe Some(List(header, ""))
     }
 
     "match a comment with trailing new lines followed by a body" in {
@@ -184,7 +184,7 @@ class CommentStyleSpec extends WordSpec with Matchers {
       val body   = """|def foo(bar):
                       |    print(bar)
                       |""".stripMargin
-      HashLineComment.pattern.unapplySeq(header + body) shouldBe Some(List(header, body))
+      hashLineComment.pattern.unapplySeq(header + body) shouldBe Some(List(header, body))
     }
   }
 
@@ -198,15 +198,15 @@ class CommentStyleSpec extends WordSpec with Matchers {
             |
             |""".stripMargin
 
-      TwirlStyleBlockComment(licenseText) shouldBe expected
+      twirlStyleBlockComment(licenseText) shouldBe expected
     }
 
     "not match a singleline comment without a trailing new line" in {
-      TwirlStyleBlockComment.pattern.unapplySeq("@* comment *@") shouldBe None
+      twirlStyleBlockComment.pattern.unapplySeq("@* comment *@") shouldBe None
     }
 
     "not match a multiline comment without a trailing new line" in {
-      TwirlStyleBlockComment.pattern.unapplySeq(
+      twirlStyleBlockComment.pattern.unapplySeq(
         """|@*
            | * comment/1
            | * comment/2
@@ -218,7 +218,7 @@ class CommentStyleSpec extends WordSpec with Matchers {
       val header = """|@* comment *@
                       |
                       |""".stripMargin
-      TwirlStyleBlockComment.pattern.unapplySeq(header) shouldBe Some(List(header, ""))
+      twirlStyleBlockComment.pattern.unapplySeq(header) shouldBe Some(List(header, ""))
     }
 
     "match a comment with a trailing new line followed by a body" in {
@@ -237,7 +237,7 @@ class CommentStyleSpec extends WordSpec with Matchers {
                       |
                       |}
                       |""".stripMargin
-      TwirlStyleBlockComment.pattern.unapplySeq(header + body) shouldBe Some(List(header, body))
+      twirlStyleBlockComment.pattern.unapplySeq(header + body) shouldBe Some(List(header, body))
     }
 
     "match a comment with a trailing new line followed by a body with a twirl block comment" in {
@@ -259,7 +259,7 @@ class CommentStyleSpec extends WordSpec with Matchers {
                       |
                       |}
                       |""".stripMargin
-      TwirlStyleBlockComment.pattern.unapplySeq(header + body) shouldBe Some(List(header, body))
+      twirlStyleBlockComment.pattern.unapplySeq(header + body) shouldBe Some(List(header, body))
     }
   }
 
@@ -273,15 +273,15 @@ class CommentStyleSpec extends WordSpec with Matchers {
             |
             |""".stripMargin
 
-      TwirlStyleFramedBlockComment(licenseText) shouldBe expected
+      twirlStyleFramedBlockComment(licenseText) shouldBe expected
     }
 
     "not match a singleline comment without a trailing new line" in {
-      TwirlStyleFramedBlockComment.pattern.unapplySeq("@* comment *@") shouldBe None
+      twirlStyleFramedBlockComment.pattern.unapplySeq("@* comment *@") shouldBe None
     }
 
     "not match a multiline comment without a trailing new line" in {
-      TwirlStyleFramedBlockComment.pattern.unapplySeq(
+      twirlStyleFramedBlockComment.pattern.unapplySeq(
         """|@*************
            | * comment/1 *
            | * comment/2 *
@@ -293,7 +293,7 @@ class CommentStyleSpec extends WordSpec with Matchers {
       val header = """|@* comment *@
                       |
                       |""".stripMargin
-      TwirlStyleFramedBlockComment.pattern.unapplySeq(header) shouldBe Some(List(header, ""))
+      twirlStyleFramedBlockComment.pattern.unapplySeq(header) shouldBe Some(List(header, ""))
     }
 
     "match a comment with a trailing new line followed by a body" in {
@@ -306,7 +306,7 @@ class CommentStyleSpec extends WordSpec with Matchers {
                       |
                       |<h1>Hello @name!</h1>
                       |""".stripMargin
-      TwirlStyleFramedBlockComment.pattern.unapplySeq(header + body) shouldBe Some(
+      twirlStyleFramedBlockComment.pattern.unapplySeq(header + body) shouldBe Some(
         List(header, body)
       )
     }
@@ -325,7 +325,7 @@ class CommentStyleSpec extends WordSpec with Matchers {
                       |<h1>Hello @name!</h1>
                       |
                       |""".stripMargin
-      TwirlStyleFramedBlockComment.pattern.unapplySeq(header + body) shouldBe Some(
+      twirlStyleFramedBlockComment.pattern.unapplySeq(header + body) shouldBe Some(
         List(header, body)
       )
     }
@@ -344,7 +344,7 @@ class CommentStyleSpec extends WordSpec with Matchers {
                       |<h1>Hello @name!</h1>
                       |
                       |""".stripMargin
-      TwirlStyleFramedBlockComment.pattern.unapplySeq(header + body) shouldBe Some(
+      twirlStyleFramedBlockComment.pattern.unapplySeq(header + body) shouldBe Some(
         List(header, body)
       )
     }
@@ -360,15 +360,15 @@ class CommentStyleSpec extends WordSpec with Matchers {
             |
             |""".stripMargin
 
-      XmlStyleBlockComment(licenseText) shouldBe expected
+      xmlStyleBlockComment(licenseText) shouldBe expected
     }
 
     "not match a single line comment without a trailing new line" in {
-      CStyleBlockComment.pattern.unapplySeq("<!-- comment -->") shouldBe None
+      cStyleBlockComment.pattern.unapplySeq("<!-- comment -->") shouldBe None
     }
 
     "not match a multi line comment without a trailing new line" in {
-      XmlStyleBlockComment.pattern.unapplySeq(
+      xmlStyleBlockComment.pattern.unapplySeq(
         """|<!--
            |   comment/1
            |   comment/2
@@ -380,7 +380,7 @@ class CommentStyleSpec extends WordSpec with Matchers {
       val header = """|<!-- comment -->
                       |
                       |""".stripMargin
-      XmlStyleBlockComment.pattern.unapplySeq(header) shouldBe Some(List(header, ""))
+      xmlStyleBlockComment.pattern.unapplySeq(header) shouldBe Some(List(header, ""))
     }
 
     "match a comment with a trailing new line followed by a body" in {
@@ -393,7 +393,7 @@ class CommentStyleSpec extends WordSpec with Matchers {
                       |  <item quantity="5" name="Bottle of Beer" />
                       |</order>
                       |""".stripMargin
-      XmlStyleBlockComment.pattern.unapplySeq(header + body) shouldBe Some(List(header, body))
+      xmlStyleBlockComment.pattern.unapplySeq(header + body) shouldBe Some(List(header, body))
     }
   }
 

--- a/src/test/scala/de/heikoseeberger/sbtheader/HeaderCreatorSpec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/HeaderCreatorSpec.scala
@@ -20,7 +20,7 @@ import java.io.ByteArrayInputStream
 
 import org.scalatest.{ Matchers, WordSpec }
 import sbt.Logger
-import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.HeaderCommentStyle.HashLineComment
+import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.HeaderCommentStyle.hashLineComment
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.HeaderLicense.Custom
 
 final class StubLogger extends Logger {
@@ -39,7 +39,7 @@ final class HeaderCreatorSpec extends WordSpec with Matchers {
 
       "produce a file with crlf line endings from a header with crlf line endings" in {
         val licenseText = "this is a header text with lf endings\r\n"
-        val header      = HashLineComment(licenseText)
+        val header      = hashLineComment(licenseText)
 
         createHeader(fileContent, licenseText) shouldBe Some(
           header.replace(newLine, "\r\n") + fileContent
@@ -48,7 +48,7 @@ final class HeaderCreatorSpec extends WordSpec with Matchers {
 
       "produce a file with crlf line endings from a header with lf line endings" in {
         val licenseText = "this is a header text with lf endings\n"
-        val header      = HashLineComment(licenseText)
+        val header      = hashLineComment(licenseText)
 
         createHeader(fileContent, licenseText) shouldBe Some(
           header.replace(newLine, "\r\n") + fileContent
@@ -62,7 +62,7 @@ final class HeaderCreatorSpec extends WordSpec with Matchers {
 
       "produce a file with lf line endings from a header with lf line endings" in {
         val licenseText = "this is a header text with lf endings\n"
-        val header      = HashLineComment(licenseText)
+        val header      = hashLineComment(licenseText)
 
         createHeader(fileContent, licenseText) shouldBe Some(
           header.replace(newLine, "\n") + fileContent
@@ -71,7 +71,7 @@ final class HeaderCreatorSpec extends WordSpec with Matchers {
 
       "produce a file with lf line endings from a header with crlf line endings" in {
         val licenseText = "this is a header text with crlf endings\r\n"
-        val header      = HashLineComment(licenseText)
+        val header      = hashLineComment(licenseText)
 
         createHeader(fileContent, licenseText) shouldBe Some(
           header.replace(newLine, "\n") + fileContent
@@ -83,7 +83,7 @@ final class HeaderCreatorSpec extends WordSpec with Matchers {
       "produce a file with cr line endings from a header with crlf line endings" in {
         val fileContent = "this is a file with cr endings\r"
         val licenseText = "this is a header text with crlf endings\r\n"
-        val header      = HashLineComment(licenseText)
+        val header      = hashLineComment(licenseText)
 
         createHeader(fileContent, licenseText) shouldBe Some(
           header.replace(newLine, "\r") + fileContent
@@ -98,7 +98,7 @@ final class HeaderCreatorSpec extends WordSpec with Matchers {
         "this is a file with lf endings\n" +
         "this is a file with lf endings\n"
         val licenseText = "this is a header text with multiple lf endings\n\n\n\n"
-        val header      = HashLineComment(licenseText)
+        val header      = hashLineComment(licenseText)
 
         createHeader(fileContent, licenseText) shouldBe Some(
           header.replace(newLine, "\n") + fileContent
@@ -111,7 +111,7 @@ final class HeaderCreatorSpec extends WordSpec with Matchers {
       "work" in {
         val fileContent = "this is a file with lf endings\n" * 50
         val licenseText = "this is a header text with multiple lf endings\n"
-        val header      = HashLineComment(licenseText)
+        val header      = hashLineComment(licenseText)
 
         createHeader(fileContent, licenseText) shouldBe Some(
           header.replace(newLine, "\n") + fileContent
@@ -127,7 +127,7 @@ final class HeaderCreatorSpec extends WordSpec with Matchers {
            |exit 0
            |""".stripMargin
       val licenseText = "Copyright 2015 Heiko Seeberger"
-      val header      = HashLineComment(licenseText)
+      val header      = hashLineComment(licenseText)
 
       "preserve shebang and add header when header is missing" in {
         val fileContent = shebang + script
@@ -159,7 +159,7 @@ final class HeaderCreatorSpec extends WordSpec with Matchers {
            |</project>
            |""".stripMargin
       val licenseText = "Copyright 2015 Heiko Seeberger"
-      val header      = HashLineComment(licenseText)
+      val header      = hashLineComment(licenseText)
 
       "preserve XML declaration and add header when header is missing" in {
         val fileContent    = xmlDeclaration + xmlBody
@@ -175,7 +175,7 @@ final class HeaderCreatorSpec extends WordSpec with Matchers {
         val licenseText = "license with UTF-8 chars $ → €\n"
 
         createHeader(fileContent, licenseText) shouldBe Some(
-          HashLineComment(licenseText).replace(newLine, "\n") + fileContent
+          hashLineComment(licenseText).replace(newLine, "\n") + fileContent
         )
       }
     }
@@ -184,7 +184,7 @@ final class HeaderCreatorSpec extends WordSpec with Matchers {
   private def createHeader(fileContent: String, header: String, fileType: FileType = FileType.sh) =
     HeaderCreator(
       fileType,
-      HashLineComment,
+      hashLineComment,
       Custom(header),
       new StubLogger,
       new ByteArrayInputStream(fileContent.getBytes)


### PR DESCRIPTION
There is no reason to configure comment styles using inheritance. It
easier to simply have one case class which can be configured via
constructor parameters.

This fixes #137.