### PR TITLE
Have headerCheck and headerCreate work on the same files

### DIFF
--- a/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala
@@ -102,8 +102,8 @@ object HeaderPlugin extends AutoPlugin {
         streams.value.log
       ),
       headerCheck := checkHeadersTask(
-        unmanagedSources.in(headerCheck).value.toList ++
-        unmanagedResources.in(headerCheck).value.toList,
+        unmanagedSources.in(headerCreate).value.toList ++
+        unmanagedResources.in(headerCreate).value.toList,
         headerLicense.value.getOrElse(sys.error("Unable to auto detect project license")),
         headerMappings.value,
         streams.value.log

--- a/src/sbt-test/sbt-header/auto-detection/test
+++ b/src/sbt-test/sbt-header/auto-detection/test
@@ -1,3 +1,5 @@
 # check if headers get created
+-> headerCheck
 > headerCreate
 > checkFileContents
+> headerCheck

--- a/src/sbt-test/sbt-header/custom-license/test
+++ b/src/sbt-test/sbt-header/custom-license/test
@@ -1,3 +1,5 @@
 # check if headers get created
+-> headerCheck
 > headerCreate
 > checkFileContents
+> headerCheck

--- a/src/sbt-test/sbt-header/excludes/test
+++ b/src/sbt-test/sbt-header/excludes/test
@@ -1,3 +1,5 @@
 # check if headers get created
+-> headerCheck
 > headerCreate
 > checkFileContents
+> headerCheck

--- a/src/sbt-test/sbt-header/override-default-mappings/test
+++ b/src/sbt-test/sbt-header/override-default-mappings/test
@@ -1,3 +1,5 @@
 # check if headers get created
+-> headerCheck
 > headerCreate
 > checkFileContents
+> headerCheck

--- a/src/sbt-test/sbt-header/simple/test
+++ b/src/sbt-test/sbt-header/simple/test
@@ -1,3 +1,5 @@
 # check if headers get created
+-> headerCheck
 > headerCreate
 > checkFileContents
+> headerCheck

--- a/src/sbt-test/sbt-header/xml/test
+++ b/src/sbt-test/sbt-header/xml/test
@@ -1,3 +1,5 @@
 # check if headers get created
+-> headerCheck
 > headerCreate
 > checkFileContents
+> headerCheck


### PR DESCRIPTION
This fixes #149.

Note that I've updated most tests to make sure:
- `headerCheck` fails before headers are created
- `headerCheck` succeeds after headers are created

That's the most straightforward way I could think of testing for this change, but let me know if you have a better idea or mislike me messing with your tests.