### PR TITLE
Exclude sources from header creation, not compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ copyright year in existing headers but still update the rest:
 To exclude some files, use the [sbt's file filters](http://www.scala-sbt.org/0.13/docs/Howto-Customizing-Paths.html#Include%2Fexclude+files+in+the+source+directory):
 
 ``` scala
-excludeFilter.in(unmanagedSources.in(headerCreate)) := HiddenFileFilter || "*Excluded.scala"
+unmanagedSourcesExcludeFilter.in(headerCreate) := HiddenFileFilter || "*Excluded.scala"
 ```
 
 ### Using an auto plugin

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ copyright year in existing headers but still update the rest:
 To exclude some files, use the [sbt's file filters](http://www.scala-sbt.org/0.13/docs/Howto-Customizing-Paths.html#Include%2Fexclude+files+in+the+source+directory):
 
 ``` scala
-unmanagedSourcesExcludeFilter.in(headerCreate) := HiddenFileFilter || "*Excluded.scala"
+excludeFilter.in(headerSources) := HiddenFileFilter || "*Excluded.scala"
 ```
 
 ### Using an auto plugin
@@ -200,7 +200,7 @@ import play.twirl.sbt.Import.TwirlKeys
 
 headerMappings := headerMappings.value + (FileType("html") -> HeaderCommentStyle.twirlStyleBlockComment)
 
-unmanagedSources.in(Compile, headerCreate) ++= sources.in(Compile, TwirlKeys.compileTemplates).value
+headerSources.in(Compile) ++= sources.in(Compile, TwirlKeys.compileTemplates).value
 ```
 
 sbt-header supports two comment styles for Twirl templates. `twirlStyleBlockComment` will produce simple twirl block comments, while `twirlStyleFramedBlockComment` will produce

--- a/src/sbt-test/sbt-header/excludes/test
+++ b/src/sbt-test/sbt-header/excludes/test
@@ -1,5 +1,5 @@
 # check if headers get created
 -> headerCheck
 > headerCreate
-> checkFileContents
+> checkFiles
 > headerCheck

--- a/src/sbt-test/sbt-header/excludes/test.sbt
+++ b/src/sbt-test/sbt-header/excludes/test.sbt
@@ -1,9 +1,9 @@
 headerLicense := Some(HeaderLicense.ALv2("2015", "Heiko Seeberger"))
 
-excludeFilter.in(unmanagedSources.in(headerCreate)) := HiddenFileFilter || "*Excluded.scala"
+unmanagedSourcesExcludeFilter.in(headerCreate) := HiddenFileFilter || "*Excluded.scala"
 
-val checkFileContents = taskKey[Unit]("Verify file contents match expected contents")
-checkFileContents := {
+val checkFiles = taskKey[Unit]("Verify files match expected files")
+checkFiles := {
 
   val includeFiles = Seq(
     (scalaSource.in(Compile).value / "Included.scala").toString,
@@ -16,13 +16,46 @@ checkFileContents := {
     (scalaSource.in(Compile).value / "de/heikoseeberger/mixed/Excluded.scala").toString
   )
 
+  // Check list of source files to process
+
+  val nonHeaderCreateSources = unmanagedSources.in(Compile).value
+  val headerCreateSources = unmanagedSources.in(Compile, headerCreate).value
+
+  def assertPathSetEquality(a: Seq[File], b: Seq[File], failureMessage: String): Unit = {
+    val aSet = a.map(_.getCanonicalPath).toSet
+    val bSet = b.map(_.getCanonicalPath).toSet
+    if (aSet != bSet) {
+      val abDiff = a diff b
+      val baDiff = b diff a
+      sys.error(
+        s"""|$failureMessage.
+            |  actual: $aSet
+            |  expected: $bSet
+            |  actual - expected: $abDiff
+            |  expected - actual: $baDiff
+            |""".stripMargin)
+
+    }
+  }
+
+  assertPathSetEquality(
+    nonHeaderCreateSources,
+    (includeFiles ++ excludeFiles).map(new File(_)),
+    "Expected source files for other (non-headerCreate) tasks to match include and exclude files.")
+  assertPathSetEquality(
+    headerCreateSources,
+    includeFiles.map(new File(_)),
+    "Expected source files for headerCreate task to match include files only.")
+
+  // Check contents of files
+
   val expectedExcludedFile = (resourceDirectory.in(Compile).value / "Excluded.scala_expected").toString
   val expectedIncludedFile = (resourceDirectory.in(Compile).value / "Included.scala_expected").toString
 
-  checkFiles(excludeFiles, expectedExcludedFile)
-  checkFiles(includeFiles, expectedIncludedFile)
+  checkFileContents(excludeFiles, expectedExcludedFile)
+  checkFileContents(includeFiles, expectedIncludedFile)
 
-  def checkFiles(filePaths: Seq[String], expectedPath: String) = {
+  def checkFileContents(filePaths: Seq[String], expectedPath: String) = {
     val expected = scala.io.Source.fromFile(expectedPath).mkString
 
     filePaths.foreach { actualPath =>

--- a/src/sbt-test/sbt-header/excludes/test.sbt
+++ b/src/sbt-test/sbt-header/excludes/test.sbt
@@ -1,6 +1,6 @@
 headerLicense := Some(HeaderLicense.ALv2("2015", "Heiko Seeberger"))
 
-unmanagedSourcesExcludeFilter.in(headerCreate) := HiddenFileFilter || "*Excluded.scala"
+excludeFilter.in(headerSources) := HiddenFileFilter || "*Excluded.scala"
 
 val checkFiles = taskKey[Unit]("Verify files match expected files")
 checkFiles := {
@@ -19,7 +19,7 @@ checkFiles := {
   // Check list of source files to process
 
   val nonHeaderCreateSources = unmanagedSources.in(Compile).value
-  val headerCreateSources = unmanagedSources.in(Compile, headerCreate).value
+  val headerCreateSources = headerSources.in(Compile).value
 
   def assertPathSetEquality(a: Seq[File], b: Seq[File], failureMessage: String): Unit = {
     val aSet = a.map(_.getCanonicalPath).toSet


### PR DESCRIPTION
Fixes #130.

Provides a way to exclude sources from header creation without also excluding sources from compilation.

I believe the current setting - `excludeFilter.in(unmanagedSources.in(headerCreate))` - doesn't work because it flattens out to be the same as simply `excludeFilter.in(unmanagedSources)`. This will override the compilation path. To work around this I create several new named settings, allowing us to avoid the flattening. (Is there a better way?)

We could also leave it up to the user to use the `collectFiles(...)` method to do their own filtering, but I think this way is easier for users, so I defined `unmanagedSources.in(headerCreate)` to explicitly depend on its directories and filters.

I've tried a few different ways of doing this, and this is the best approach I could find, but I'm not that great at sbt, so would appreciate review (cc @eed3si9n).