### PR TITLE
Add an example of excluding from headerResources

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ To exclude some files, use the [sbt's file filters](http://www.scala-sbt.org/0.1
 
 ``` scala
 excludeFilter.in(headerSources) := HiddenFileFilter || "*Excluded.scala"
+excludeFilter.in(headerResources) := HiddenFileFilter || "*.xml"
 ```
 
 ### Using an auto plugin


### PR DESCRIPTION
This helps clarify that there are two different settings available for source files and resource files.