### PR TITLE
Add the ability to use short SPDX license syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,23 @@ The most common licenses have been pre-canned in [License](https://github.com/sb
 |[MIT License](https://opensource.org/licenses/MIT)|`MIT`|
 |[Mozilla Public License, v. 2.0](http://mozilla.org/MPL/2.0/)|`MPL-2.0`|
 
+### Using the short SPDX license identifier syntax
+
+If you want to use the following syntax:
+```
+  /*
+   * Copyright 2015 Heiko Seeberger
+   *
+   * SPDX-License-Identifier: BSD-3-Clause
+   */
+```
+
+You have to pass the style when defining the headerLicense attribute
+
+```scala
+headerLicense := Some(HeaderLicense.MIT("2015", "Heiko Seeberger", HeaderLicenseStyle.SpdxSyntax))
+```
+
 ### Using a custom license text
 
 If you don't want to use one of the built-in licenses, you can define a custom license text using the `Custom` case class:

--- a/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala
@@ -46,6 +46,8 @@ object HeaderPlugin extends AutoPlugin {
 
     val HeaderLicense = License
 
+    val HeaderLicenseStyle = LicenseStyle
+
     final object HeaderPattern {
 
       def commentBetween(start: String, middle: String, end: String): Regex =

--- a/src/main/scala/de/heikoseeberger/sbtheader/License.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/License.scala
@@ -16,6 +16,8 @@
 
 package de.heikoseeberger.sbtheader
 
+import de.heikoseeberger.sbtheader.LicenseStyle.{ Detailed, SpdxSyntax }
+
 sealed trait License {
   def text: String
 }
@@ -24,7 +26,7 @@ sealed trait SpdxLicense {
 
   def spdxIdentifier: String
 
-  def apply(yyyy: String, copyrightOwner: String): License
+  def apply(yyyy: String, copyrightOwner: String, licenseStyle: LicenseStyle = Detailed): License
 }
 
 object License {
@@ -32,84 +34,113 @@ object License {
   private[sbtheader] val spdxLicenses =
     Vector(ALv2, MIT, MPLv2, BSD2Clause, BSD3Clause, GPLv3, LGPLv3, AGPLv3)
 
+  private[sbtheader] def buildSpdxSyntax(yyyy: String,
+                                         copyrightOwner: String,
+                                         spdxIdentifier: String): String =
+    s"""|Copyright $yyyy $copyrightOwner
+        |
+        |SPDX-License-Identifier: $spdxIdentifier
+        |""".stripMargin
+
   final case object ALv2 extends SpdxLicense {
 
     override val spdxIdentifier = "Apache-2.0"
 
-    override def apply(yyyy: String, copyrightOwner: String) = new ALv2(yyyy, copyrightOwner)
+    override def apply(yyyy: String, copyrightOwner: String, licenseStyle: LicenseStyle) =
+      new ALv2(yyyy, copyrightOwner, licenseStyle)
   }
 
-  final class ALv2(yyyy: String, copyrightOwner: String) extends License {
+  final class ALv2(yyyy: String, copyrightOwner: String, licenseStyle: LicenseStyle)
+      extends License {
 
-    override val text =
-      s"""|Copyright $yyyy $copyrightOwner
-          |
-          |Licensed under the Apache License, Version 2.0 (the "License");
-          |you may not use this file except in compliance with the License.
-          |You may obtain a copy of the License at
-          |
-          |    http://www.apache.org/licenses/LICENSE-2.0
-          |
-          |Unless required by applicable law or agreed to in writing, software
-          |distributed under the License is distributed on an "AS IS" BASIS,
-          |WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-          |See the License for the specific language governing permissions and
-          |limitations under the License.
-          |""".stripMargin
+    override val text: String = licenseStyle match {
+      case SpdxSyntax =>
+        buildSpdxSyntax(yyyy, copyrightOwner, ALv2.spdxIdentifier)
+
+      case Detailed =>
+        s"""|Copyright $yyyy $copyrightOwner
+            |
+            |Licensed under the Apache License, Version 2.0 (the "License");
+            |you may not use this file except in compliance with the License.
+            |You may obtain a copy of the License at
+            |
+            |    http://www.apache.org/licenses/LICENSE-2.0
+            |
+            |Unless required by applicable law or agreed to in writing, software
+            |distributed under the License is distributed on an "AS IS" BASIS,
+            |WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+            |See the License for the specific language governing permissions and
+            |limitations under the License.
+            |""".stripMargin
+    }
   }
 
   final case object MIT extends SpdxLicense {
 
     override def spdxIdentifier = "MIT"
 
-    override def apply(yyyy: String, copyrightOwner: String) = new MIT(yyyy, copyrightOwner)
+    override def apply(yyyy: String, copyrightOwner: String, licenseStyle: LicenseStyle) =
+      new MIT(yyyy, copyrightOwner, licenseStyle)
   }
 
-  final class MIT(yyyy: String, copyrightOwner: String) extends License {
+  final class MIT(yyyy: String, copyrightOwner: String, licenseStyle: LicenseStyle)
+      extends License {
 
-    override val text =
-      s"""|Copyright (c) $yyyy $copyrightOwner
-          |
-          |Permission is hereby granted, free of charge, to any person obtaining a copy of
-          |this software and associated documentation files (the "Software"), to deal in
-          |the Software without restriction, including without limitation the rights to
-          |use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-          |the Software, and to permit persons to whom the Software is furnished to do so,
-          |subject to the following conditions:
-          |
-          |The above copyright notice and this permission notice shall be included in all
-          |copies or substantial portions of the Software.
-          |
-          |THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-          |IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-          |FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-          |COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-          |IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-          |CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-          |""".stripMargin
+    override val text: String = licenseStyle match {
+      case SpdxSyntax =>
+        buildSpdxSyntax(yyyy, copyrightOwner, MIT.spdxIdentifier)
+
+      case Detailed =>
+        s"""|Copyright (c) $yyyy $copyrightOwner
+            |
+            |Permission is hereby granted, free of charge, to any person obtaining a copy of
+            |this software and associated documentation files (the "Software"), to deal in
+            |the Software without restriction, including without limitation the rights to
+            |use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+            |the Software, and to permit persons to whom the Software is furnished to do so,
+            |subject to the following conditions:
+            |
+            |The above copyright notice and this permission notice shall be included in all
+            |copies or substantial portions of the Software.
+            |
+            |THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+            |IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+            |FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+            |COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+            |IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+            |CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+            |""".stripMargin
+    }
   }
 
   final case object MPLv2 extends SpdxLicense {
 
     override def spdxIdentifier = "MPL-2.0"
 
-    override def apply(yyyy: String, copyrightOwner: String) = new MPLv2(yyyy, copyrightOwner)
+    override def apply(yyyy: String, copyrightOwner: String, licenseStyle: LicenseStyle) =
+      new MPLv2(yyyy, copyrightOwner, licenseStyle)
   }
 
-  final class MPLv2(yyyy: String, copyrightOwner: String) extends License {
+  final class MPLv2(yyyy: String, copyrightOwner: String, licenseStyle: LicenseStyle)
+      extends License {
 
-    override val text =
-      s"""|Copyright (c) $yyyy $copyrightOwner
-          |
-          |This Source Code Form is subject to the terms of the Mozilla Public
-          |License, v. 2.0. If a copy of the MPL was not distributed with this
-          |file, You can obtain one at http://mozilla.org/MPL/2.0/.
-          |""".stripMargin
+    override val text: String = licenseStyle match {
+      case SpdxSyntax =>
+        buildSpdxSyntax(yyyy, copyrightOwner, MPLv2.spdxIdentifier)
+
+      case Detailed =>
+        s"""|Copyright (c) $yyyy $copyrightOwner
+            |
+            |This Source Code Form is subject to the terms of the Mozilla Public
+            |License, v. 2.0. If a copy of the MPL was not distributed with this
+            |file, You can obtain one at http://mozilla.org/MPL/2.0/.
+            |""".stripMargin
+    }
   }
 
   final object MPLv2_NoCopyright extends License {
 
-    override val text =
+    override val text: String =
       s"""|This Source Code Form is subject to the terms of the Mozilla Public
           |License, v. 2.0. If a copy of the MPL was not distributed with this
           |file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -120,156 +151,190 @@ object License {
 
     override def spdxIdentifier = "BSD-2-Clause"
 
-    override def apply(yyyy: String, copyrightOwner: String) = new BSD2Clause(yyyy, copyrightOwner)
+    override def apply(yyyy: String, copyrightOwner: String, licenseStyle: LicenseStyle) =
+      new BSD2Clause(yyyy, copyrightOwner, licenseStyle)
   }
 
-  final class BSD2Clause(yyyy: String, copyrightOwner: String) extends License {
+  final class BSD2Clause(yyyy: String, copyrightOwner: String, licenseStyle: LicenseStyle)
+      extends License {
 
-    override val text =
-      s"""|Copyright (c) $yyyy, $copyrightOwner
-          |All rights reserved.
-          |
-          |Redistribution and use in source and binary forms, with or without modification,
-          |are permitted provided that the following conditions are met:
-          |
-          |1. Redistributions of source code must retain the above copyright notice, this
-          |   list of conditions and the following disclaimer.
-          |
-          |2. Redistributions in binary form must reproduce the above copyright notice,
-          |   this list of conditions and the following disclaimer in the documentation
-          |   and/or other materials provided with the distribution.
-          |
-          |THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-          |ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-          |WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-          |DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-          |ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-          |(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-          |LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-          |ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-          |(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-          |SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-          |""".stripMargin
+    override val text: String = licenseStyle match {
+      case SpdxSyntax =>
+        buildSpdxSyntax(yyyy, copyrightOwner, BSD2Clause.spdxIdentifier)
+
+      case Detailed =>
+        s"""|Copyright (c) $yyyy, $copyrightOwner
+            |All rights reserved.
+            |
+            |Redistribution and use in source and binary forms, with or without modification,
+            |are permitted provided that the following conditions are met:
+            |
+            |1. Redistributions of source code must retain the above copyright notice, this
+            |   list of conditions and the following disclaimer.
+            |
+            |2. Redistributions in binary form must reproduce the above copyright notice,
+            |   this list of conditions and the following disclaimer in the documentation
+            |   and/or other materials provided with the distribution.
+            |
+            |THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+            |ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+            |WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+            |DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+            |ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+            |(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+            |LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+            |ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+            |(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+            |SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+            |""".stripMargin
+    }
   }
 
   final case object BSD3Clause extends SpdxLicense {
 
     override def spdxIdentifier = "BSD-3-Clause"
 
-    override def apply(yyyy: String, copyrightOwner: String) = new BSD3Clause(yyyy, copyrightOwner)
+    override def apply(yyyy: String, copyrightOwner: String, licenseStyle: LicenseStyle) =
+      new BSD3Clause(yyyy, copyrightOwner, licenseStyle)
   }
 
-  final class BSD3Clause(yyyy: String, copyrightOwner: String) extends License {
+  final class BSD3Clause(yyyy: String, copyrightOwner: String, licenseStyle: LicenseStyle)
+      extends License {
 
-    override val text =
-      s"""|Copyright (c) $yyyy, $copyrightOwner
-          |All rights reserved.
-          |
-          |Redistribution and use in source and binary forms, with or without modification,
-          |are permitted provided that the following conditions are met:
-          |
-          |1. Redistributions of source code must retain the above copyright notice, this
-          |   list of conditions and the following disclaimer.
-          |
-          |2. Redistributions in binary form must reproduce the above copyright notice,
-          |   this list of conditions and the following disclaimer in the documentation
-          |   and/or other materials provided with the distribution.
-          |
-          |3. Neither the name of the copyright holder nor the names of its contributors
-          |   may be used to endorse or promote products derived from this software without
-          |   specific prior written permission.
-          |
-          |THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-          |ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-          |WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-          |DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-          |ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-          |(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-          |LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-          |ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-          |(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-          |SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-          |""".stripMargin
+    override val text: String = licenseStyle match {
+      case SpdxSyntax =>
+        buildSpdxSyntax(yyyy, copyrightOwner, BSD3Clause.spdxIdentifier)
+
+      case Detailed =>
+        s"""|Copyright (c) $yyyy, $copyrightOwner
+            |All rights reserved.
+            |
+            |Redistribution and use in source and binary forms, with or without modification,
+            |are permitted provided that the following conditions are met:
+            |
+            |1. Redistributions of source code must retain the above copyright notice, this
+            |   list of conditions and the following disclaimer.
+            |
+            |2. Redistributions in binary form must reproduce the above copyright notice,
+            |   this list of conditions and the following disclaimer in the documentation
+            |   and/or other materials provided with the distribution.
+            |
+            |3. Neither the name of the copyright holder nor the names of its contributors
+            |   may be used to endorse or promote products derived from this software without
+            |   specific prior written permission.
+            |
+            |THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+            |ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+            |WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+            |DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+            |ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+            |(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+            |LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+            |ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+            |(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+            |SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+            |""".stripMargin
+    }
   }
 
   final case object GPLv3 extends SpdxLicense {
 
     override def spdxIdentifier = "GPL-3.0"
 
-    override def apply(yyyy: String, copyrightOwner: String) = new GPLv3(yyyy, copyrightOwner)
+    override def apply(yyyy: String, copyrightOwner: String, licenseStyle: LicenseStyle) =
+      new GPLv3(yyyy, copyrightOwner, licenseStyle)
   }
 
-  final class GPLv3(yyyy: String, copyrightOwner: String) extends License {
+  final class GPLv3(yyyy: String, copyrightOwner: String, licenseStyle: LicenseStyle)
+      extends License {
 
-    override val text =
-      s"""|Copyright (C) $yyyy  $copyrightOwner
-          |
-          |This program is free software: you can redistribute it and/or modify
-          |it under the terms of the GNU General Public License as published by
-          |the Free Software Foundation, either version 3 of the License, or
-          |(at your option) any later version.
-          |
-          |This program is distributed in the hope that it will be useful,
-          |but WITHOUT ANY WARRANTY; without even the implied warranty of
-          |MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-          |GNU General Public License for more details.
-          |
-          |You should have received a copy of the GNU General Public License
-          |along with this program.  If not, see <http://www.gnu.org/licenses/>.
-          |""".stripMargin
+    override val text: String = licenseStyle match {
+      case SpdxSyntax =>
+        buildSpdxSyntax(yyyy, copyrightOwner, GPLv3.spdxIdentifier)
+
+      case Detailed =>
+        s"""|Copyright (C) $yyyy  $copyrightOwner
+            |
+            |This program is free software: you can redistribute it and/or modify
+            |it under the terms of the GNU General Public License as published by
+            |the Free Software Foundation, either version 3 of the License, or
+            |(at your option) any later version.
+            |
+            |This program is distributed in the hope that it will be useful,
+            |but WITHOUT ANY WARRANTY; without even the implied warranty of
+            |MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+            |GNU General Public License for more details.
+            |
+            |You should have received a copy of the GNU General Public License
+            |along with this program.  If not, see <http://www.gnu.org/licenses/>.
+            |""".stripMargin
+    }
   }
 
   final case object LGPLv3 extends SpdxLicense {
 
     override def spdxIdentifier = "LGPL-3.0"
 
-    override def apply(yyyy: String, copyrightOwner: String) = new LGPLv3(yyyy, copyrightOwner)
+    override def apply(yyyy: String, copyrightOwner: String, licenseStyle: LicenseStyle) =
+      new LGPLv3(yyyy, copyrightOwner, licenseStyle)
   }
 
-  final class LGPLv3(yyyy: String, copyrightOwner: String) extends License {
-    override val text =
-      s"""|Copyright (C) $yyyy  $copyrightOwner
-          |
-          |This program is free software: you can redistribute it and/or modify
-          |it under the terms of the GNU Lesser General Public License as published
-          |by the Free Software Foundation, either version 3 of the License, or
-          |(at your option) any later version.
-          |
-          |This program is distributed in the hope that it will be useful,
-          |but WITHOUT ANY WARRANTY; without even the implied warranty of
-          |MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-          |GNU Lesser General Public License for more details.
-          |
-          |You should have received a copy of the GNU General Lesser Public License
-          |along with this program.  If not, see <http://www.gnu.org/licenses/>.
-          |""".stripMargin
+  final class LGPLv3(yyyy: String, copyrightOwner: String, licenseStyle: LicenseStyle)
+      extends License {
+    override val text: String = licenseStyle match {
+      case SpdxSyntax =>
+        buildSpdxSyntax(yyyy, copyrightOwner, LGPLv3.spdxIdentifier)
+
+      case Detailed =>
+        s"""|Copyright (C) $yyyy  $copyrightOwner
+            |
+            |This program is free software: you can redistribute it and/or modify
+            |it under the terms of the GNU Lesser General Public License as published
+            |by the Free Software Foundation, either version 3 of the License, or
+            |(at your option) any later version.
+            |
+            |This program is distributed in the hope that it will be useful,
+            |but WITHOUT ANY WARRANTY; without even the implied warranty of
+            |MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+            |GNU Lesser General Public License for more details.
+            |
+            |You should have received a copy of the GNU General Lesser Public License
+            |along with this program.  If not, see <http://www.gnu.org/licenses/>.
+            |""".stripMargin
+    }
   }
 
   final case object AGPLv3 extends SpdxLicense {
     override def spdxIdentifier = "AGPL-3.0"
 
-    override def apply(yyyy: String, copyrightOwner: String) =
-      new AGPLv3(yyyy, copyrightOwner)
+    override def apply(yyyy: String, copyrightOwner: String, licenseStyle: LicenseStyle) =
+      new AGPLv3(yyyy, copyrightOwner, licenseStyle)
   }
 
-  final class AGPLv3(yyyy: String, copyrightOwner: String) extends License {
+  final class AGPLv3(yyyy: String, copyrightOwner: String, licenseStyle: LicenseStyle)
+      extends License {
 
-    override val text =
-      s"""|Copyright (C) $yyyy  $copyrightOwner
-          |
-          |This program is free software: you can redistribute it and/or modify
-          |it under the terms of the GNU Affero General Public License as
-          |published by the Free Software Foundation, either version 3 of the
-          |License, or (at your option) any later version.
-          |
-          |This program is distributed in the hope that it will be useful,
-          |but WITHOUT ANY WARRANTY; without even the implied warranty of
-          |MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-          |GNU Affero General Public License for more details.
-          |
-          |You should have received a copy of the GNU Affero General Public License
-          |along with this program.  If not, see <http://www.gnu.org/licenses/>.
-          |""".stripMargin
+    override val text: String = licenseStyle match {
+      case SpdxSyntax =>
+        buildSpdxSyntax(yyyy, copyrightOwner, AGPLv3.spdxIdentifier)
+
+      case Detailed =>
+        s"""|Copyright (C) $yyyy  $copyrightOwner
+            |
+            |This program is free software: you can redistribute it and/or modify
+            |it under the terms of the GNU Affero General Public License as
+            |published by the Free Software Foundation, either version 3 of the
+            |License, or (at your option) any later version.
+            |
+            |This program is distributed in the hope that it will be useful,
+            |but WITHOUT ANY WARRANTY; without even the implied warranty of
+            |MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+            |GNU Affero General Public License for more details.
+            |
+            |You should have received a copy of the GNU Affero General Public License
+            |along with this program.  If not, see <http://www.gnu.org/licenses/>.
+            |""".stripMargin
+    }
   }
 
   final case class Custom(text: String) extends License

--- a/src/main/scala/de/heikoseeberger/sbtheader/LicenseStyle.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/LicenseStyle.scala
@@ -1,0 +1,9 @@
+package de.heikoseeberger.sbtheader
+
+sealed trait LicenseStyle
+
+object LicenseStyle {
+
+  final case object Detailed   extends LicenseStyle
+  final case object SpdxSyntax extends LicenseStyle
+}

--- a/src/sbt-test/sbt-header/header-style/project/test.sbt
+++ b/src/sbt-test/sbt-header/header-style/project/test.sbt
@@ -1,0 +1,6 @@
+val pluginVersion =
+  sys.props
+    .get("plugin.version")
+    .getOrElse(sys.error("Sys prop plugin.version must be defined!"))
+
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % pluginVersion)

--- a/src/sbt-test/sbt-header/header-style/src/main/resources/HasNoHeader.scala_expected
+++ b/src/sbt-test/sbt-header/header-style/src/main/resources/HasNoHeader.scala_expected
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package de.heikoseeberger.sbtheader.test;
+
+class HasNoHeader

--- a/src/sbt-test/sbt-header/header-style/src/main/scala/HasNoHeader.scala
+++ b/src/sbt-test/sbt-header/header-style/src/main/scala/HasNoHeader.scala
@@ -1,0 +1,3 @@
+package de.heikoseeberger.sbtheader.test;
+
+class HasNoHeader

--- a/src/sbt-test/sbt-header/header-style/test
+++ b/src/sbt-test/sbt-header/header-style/test
@@ -1,0 +1,5 @@
+# check if headers get created
+-> headerCheck
+> headerCreate
+> checkFileContents
+> headerCheck

--- a/src/sbt-test/sbt-header/header-style/test.sbt
+++ b/src/sbt-test/sbt-header/header-style/test.sbt
@@ -1,0 +1,25 @@
+headerLicense := Some(HeaderLicense.BSD3Clause("2015", "Heiko Seeberger", HeaderLicenseStyle.SpdxSyntax))
+
+val checkFileContents = taskKey[Unit]("Verify file contents match expected contents")
+
+checkFileContents := {
+  checkFile("HasNoHeader.scala")
+
+  def checkFile(name: String) = {
+    val actualPath = (scalaSource.in(Compile).value / name).toString
+    val expectedPath = (resourceDirectory.in(Compile).value / s"${name}_expected").toString
+
+    val actual = scala.io.Source.fromFile(actualPath).mkString
+    val expected = scala.io.Source.fromFile(expectedPath).mkString
+
+    if (actual != expected) sys.error(
+      s"""|Actual file contents do not match expected file contents!
+          |  actual: $actualPath
+          |$actual
+          |
+          |  expected: $expectedPath
+          |$expected
+          |""".stripMargin)
+  }
+}
+

--- a/src/test/scala/de/heikoseeberger/sbtheader/HeaderCreatorSpec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/HeaderCreatorSpec.scala
@@ -23,10 +23,12 @@ import sbt.Logger
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.HeaderCommentStyle.hashLineComment
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.HeaderLicense.Custom
 
+import scala.util.matching.Regex
+
 final class StubLogger extends Logger {
-  override def log(level: sbt.Level.Value, message: => String) = ()
-  override def success(message: => String)                     = ()
-  override def trace(t: => Throwable)                          = ()
+  override def log(level: sbt.Level.Value, message: => String): Unit = ()
+  override def success(message: => String): Unit                     = ()
+  override def trace(t: => Throwable): Unit                          = ()
 }
 
 final class HeaderCreatorSpec extends WordSpec with Matchers {
@@ -38,7 +40,7 @@ final class HeaderCreatorSpec extends WordSpec with Matchers {
       val fileContent = "this is a file with crlf endings\r\n"
 
       "produce a file with crlf line endings from a header with crlf line endings" in {
-        val licenseText = "this is a header text with lf endings\r\n"
+        val licenseText = "this is a header text with crlf endings\r\n"
         val header      = hashLineComment(licenseText)
 
         createHeader(fileContent, licenseText) shouldBe Some(
@@ -107,8 +109,8 @@ final class HeaderCreatorSpec extends WordSpec with Matchers {
     }
 
     //Due to java bug http://bugs.java.com/bugdatabase/view_bug.do?bug_id=8028387
-    "given a large file" should {
-      "work" in {
+    "given a large file with a lot of lf endings" should {
+      "produce a file with lf line endings from a header with lf line endings" in {
         val fileContent = "this is a file with lf endings\n" * 50
         val licenseText = "this is a header text with multiple lf endings\n"
         val header      = hashLineComment(licenseText)
@@ -183,7 +185,7 @@ final class HeaderCreatorSpec extends WordSpec with Matchers {
     "given a file with an existing copyright year" should {
       val yearPreservingStyle =
         CommentStyle.cStyleBlockComment.copy(commentCreator = new CommentCreator() {
-          val Pattern = "(?s).*?(\\d{4}(-\\d{4})?).*".r
+          val Pattern: Regex = "(?s).*?(\\d{4}(-\\d{4})?).*".r
           def findYear(header: String): Option[String] = header match {
             case Pattern(years, _) => Some(years)
             case _                 => None
@@ -216,8 +218,8 @@ final class HeaderCreatorSpec extends WordSpec with Matchers {
       }
     }
 
-    "configured not to add an empty line" should {
-      "not add it" in {
+    "given a file without an empty line between the header and the body" should {
+      "preserve the file without the empty line" in {
         val fileContent = """/*
           | * Copyright 2017 MyCorp, Inc <https://mycorp.com>
           | */

--- a/src/test/scala/de/heikoseeberger/sbtheader/LicenseDetectionSpec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/LicenseDetectionSpec.scala
@@ -25,10 +25,11 @@ class LicenseDetectionSpec extends WordSpec with Matchers {
   val organizationName = "Heiko Seeberger"
   val yyyy             = 2017
   val startYear        = Some(yyyy)
-  val apache           = ("Apache-2.0", new URL("https://spdx.org/licenses/Apache-2.0.html#licenseText"))
-  val mit              = ("MIT", new URL("https://spdx.org/licenses/MIT.html#licenseText"))
+  val apache: (String, URL) =
+    ("Apache-2.0", new URL("https://spdx.org/licenses/Apache-2.0.html#licenseText"))
+  val mit: (String, URL) = ("MIT", new URL("https://spdx.org/licenses/MIT.html#licenseText"))
 
-  val licenses = Map(
+  val licenses: Map[License, (String, URL)] = Map(
     BSD2Clause(yyyy.toString, organizationName) -> ("BSD-2-Clause", new URL(
       "https://spdx.org/licenses/BSD-2-Clause.html#licenseText"
     )),


### PR DESCRIPTION
Fixes #155 by adding a new parameter to the SpdxLicense apply function that allow the user to select between Detail or SpdxSyntax format. The parameter has the default value Detail so it's backwards compatible.

When building the license text depending on the format specified the app build the text that later is going to be set in the files.