### PR TITLE
Incremental create headers using sbt cache infra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ scala:
   - 2.12.8
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 script:
   - sbt ^test

--- a/README.md
+++ b/README.md
@@ -35,15 +35,8 @@ In order to create or update file headers, execute the `headerCreate` task:
 [info]   /Users/heiko/projects/sbt-header/sbt-header-test/test2.scala
 ```
 
-The plugin can also be triggered incrementally, meaning that it will not look at files that has not seen changes since
-the last time the task was run:
-
-```
-> headerCreateIncremental
-[info] Headers created for 2 files:
-[info]   /Users/heiko/projects/sbt-header/sbt-header-test/test.scala
-[info]   /Users/heiko/projects/sbt-header/sbt-header-test/test2.scala
-```
+The task is incremental, meaning that it will not look at files that have not seen changes since
+the last time the task was run.
 
 
 ### Checking headers

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ startYear := Some(2015)
 licenses += ("Apache-2.0", new URL("https://www.apache.org/licenses/LICENSE-2.0.txt"))
 ```
 
-This configuration will apply Apache License 2.0 headers to Scala and Java files. sbt-header provides three tasks: `headerCreate`, `headerCreateIncremental` and `headerCheck`, which are described in the following sub sections. For more information on how to customize sbt-header, please refer to the [Configuration](#configuration) section.
+This configuration will apply Apache License 2.0 headers to Scala and Java files. sbt-header provides two tasks: `headerCreate` and `headerCheck`, which are described in the following sub sections. For more information on how to customize sbt-header, please refer to the [Configuration](#configuration) section.
 
 ### Creating headers
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ startYear := Some(2015)
 licenses += ("Apache-2.0", new URL("https://www.apache.org/licenses/LICENSE-2.0.txt"))
 ```
 
-This configuration will apply Apache License 2.0 headers to Scala and Java files. sbt-header provides two tasks: `headerCreate` and `headerCheck`, which are described in the following sub sections. For more information on how to customize sbt-header, please refer to the [Configuration](#configuration) section.
+This configuration will apply Apache License 2.0 headers to Scala and Java files. sbt-header provides three tasks: `headerCreate`, `headerCreateIncremental` and `headerCheck`, which are described in the following sub sections. For more information on how to customize sbt-header, please refer to the [Configuration](#configuration) section.
 
 ### Creating headers
 
@@ -34,6 +34,17 @@ In order to create or update file headers, execute the `headerCreate` task:
 [info]   /Users/heiko/projects/sbt-header/sbt-header-test/test.scala
 [info]   /Users/heiko/projects/sbt-header/sbt-header-test/test2.scala
 ```
+
+The plugin can also be triggered incrementally, meaning that it will not look at files that has not seen changes since
+the last time the task was run:
+
+```
+> headerCreateIncremental
+[info] Headers created for 2 files:
+[info]   /Users/heiko/projects/sbt-header/sbt-header-test/test.scala
+[info]   /Users/heiko/projects/sbt-header/sbt-header-test/test2.scala
+```
+
 
 ### Checking headers
 

--- a/build.sbt
+++ b/build.sbt
@@ -58,7 +58,7 @@ lazy val commonSettings =
     unmanagedSourceDirectories.in(Compile) := Seq(scalaSource.in(Compile).value),
     unmanagedSourceDirectories.in(Test) := Seq(scalaSource.in(Test).value),
     publishMavenStyle := false,
-    crossSbtVersions := Seq("1.1.6", "0.13.17")
+    crossSbtVersions := Seq("1.1.6")
 )
 
 lazy val gitSettings =

--- a/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala
@@ -37,8 +37,10 @@ import sbt.{
 }
 import sbt.Defaults.collectFiles
 import sbt.Keys._
+import sbt.internal.util.MessageOnlyException
 import sbt.plugins.JvmPlugin
 
+import scala.util.control.NoStackTrace
 import scala.util.matching.Regex
 
 object HeaderPlugin extends AutoPlugin {
@@ -229,12 +231,12 @@ object HeaderPlugin extends AutoPlugin {
             groupedFiles.flatMap(checkHeader(fileType, commentStyle))
         }
     if (filesWithoutHeader.nonEmpty)
-      log.error(
+      throw new MessageOnlyException(
         s"""|There are files without headers!
-            |  ${filesWithoutHeader.mkString(s"$newLine  ")}
-            |""".stripMargin
+              |  ${filesWithoutHeader.mkString(s"$newLine  ")}
+              |""".stripMargin
       )
-    filesWithoutHeader
+    else Nil
   }
 
   private def groupFilesByFileTypeAndCommentStyle(files: Seq[File],

--- a/src/sbt-test/sbt-header/incremental/project/test.sbt
+++ b/src/sbt-test/sbt-header/incremental/project/test.sbt
@@ -1,0 +1,6 @@
+val pluginVersion =
+  sys.props
+    .get("plugin.version")
+    .getOrElse(sys.error("Sys prop plugin.version must be defined!"))
+
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % pluginVersion)

--- a/src/sbt-test/sbt-header/incremental/src/main/resources/HasHeader.scala_expected
+++ b/src/sbt-test/sbt-header/incremental/src/main/resources/HasHeader.scala_expected
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.heikoseeberger.sbtheader.test;
+
+class HasHeader

--- a/src/sbt-test/sbt-header/incremental/src/main/resources/HasHeader.scala_headerdropped
+++ b/src/sbt-test/sbt-header/incremental/src/main/resources/HasHeader.scala_headerdropped
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.heikoseeberger.sbtheader.test;
+
+class HasHeader

--- a/src/sbt-test/sbt-header/incremental/src/main/resources/HasNoHeader.scala_expected
+++ b/src/sbt-test/sbt-header/incremental/src/main/resources/HasNoHeader.scala_expected
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.heikoseeberger.sbtheader.test;
+
+class HasNoHeader

--- a/src/sbt-test/sbt-header/incremental/src/main/scala/HasHeader.scala
+++ b/src/sbt-test/sbt-header/incremental/src/main/scala/HasHeader.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.heikoseeberger.sbtheader.test;
+
+class HasHeader

--- a/src/sbt-test/sbt-header/incremental/src/main/scala/HasNoHeader.scala
+++ b/src/sbt-test/sbt-header/incremental/src/main/scala/HasNoHeader.scala
@@ -1,0 +1,3 @@
+package de.heikoseeberger.sbtheader.test;
+
+class HasNoHeader

--- a/src/sbt-test/sbt-header/incremental/test
+++ b/src/sbt-test/sbt-header/incremental/test
@@ -1,7 +1,7 @@
 # check if headers get created incrementally when file modified
 -> headerCheck
-> headerCreateIncremental
+> headerCreate
 > checkFileContents
 > stripHeader
-> headerCreateIncremental
+> headerCreate
 > checkFileContents

--- a/src/sbt-test/sbt-header/incremental/test
+++ b/src/sbt-test/sbt-header/incremental/test
@@ -2,6 +2,6 @@
 -> headerCheck
 > headerCreateIncremental
 > checkFileContents
-> stripHeaders
+> stripHeader
 > headerCreateIncremental
 > checkFileContents

--- a/src/sbt-test/sbt-header/incremental/test
+++ b/src/sbt-test/sbt-header/incremental/test
@@ -1,0 +1,7 @@
+# check if headers get created incrementally when file modified
+-> headerCheck
+> headerCreateIncremental
+> checkFileContents
+> stripHeaders
+> headerCreateIncremental
+> checkFileContents

--- a/src/sbt-test/sbt-header/incremental/test.sbt
+++ b/src/sbt-test/sbt-header/incremental/test.sbt
@@ -11,6 +11,7 @@ stripHeader := {
     val actualPath = (scalaSource.in(Compile).value / name).toString
     val headerDropped = (resourceDirectory.in(Compile).value / s"${name}_headerdropped").toString
 
+    Files.delete(file(actualPath).toPath)
     Files.copy(file(headerDropped).toPath, file(actualPath).toPath)
   }
 }

--- a/src/sbt-test/sbt-header/incremental/test.sbt
+++ b/src/sbt-test/sbt-header/incremental/test.sbt
@@ -1,0 +1,39 @@
+headerLicense := Some(HeaderLicense.ALv2("2015", "Heiko Seeberger"))
+
+val checkFileContents = taskKey[Unit]("Verify file contents match expected contents")
+val stripHeader = taskKey[Unit]("Strip headers")
+
+stripHeader := {
+  import java.nio.file.Files
+  stripHeader("HasHeader.scala")
+
+  def stripHeader(name: String) = {
+    val actualPath = (scalaSource.in(Compile).value / name).toString
+    val headerDropped = (resourceDirectory.in(Compile).value / s"${name}_headerdropped").toString
+
+    Files.copy(file(headerDropped).toPath, file(actualPath).toPath)
+  }
+}
+
+checkFileContents := {
+  checkFile("HasHeader.scala")
+  checkFile("HasNoHeader.scala")
+
+  def checkFile(name: String) = {
+    val actualPath = (scalaSource.in(Compile).value / name).toString
+    val expectedPath = (resourceDirectory.in(Compile).value / s"${name}_expected").toString
+
+    val actual = scala.io.Source.fromFile(actualPath).mkString
+    val expected = scala.io.Source.fromFile(expectedPath).mkString
+
+    if (actual != expected) sys.error(
+      s"""|Actual file contents do not match expected file contents!
+          |  actual: $actualPath
+          |$actual
+          |
+          |  expected: $expectedPath
+          |$expected
+          |""".stripMargin)
+  }
+}
+


### PR DESCRIPTION
Refs #168 

Nothing amazing but cuts a few seconds of a hot compile in the Akka project.

Didn't get any of the scripted tests to pass though, they log an error but scripted claims that tasks pass when they should fail.