### PR TITLE
Bugfix: Use the right sbt cache API

### DIFF
--- a/src/sbt-test/sbt-header/incremental/test
+++ b/src/sbt-test/sbt-header/incremental/test
@@ -5,3 +5,5 @@
 > stripHeader
 > headerCreate
 > checkFileContents
+> removeFile
+> headerCreate

--- a/src/sbt-test/sbt-header/incremental/test.sbt
+++ b/src/sbt-test/sbt-header/incremental/test.sbt
@@ -1,7 +1,10 @@
+import java.nio.file.Files
+
 headerLicense := Some(HeaderLicense.ALv2("2015", "Heiko Seeberger"))
 
 val checkFileContents = taskKey[Unit]("Verify file contents match expected contents")
 val stripHeader = taskKey[Unit]("Strip headers")
+val removeFile = taskKey[Unit]("Remove one file")
 
 stripHeader := {
   import java.nio.file.Files
@@ -36,5 +39,10 @@ checkFileContents := {
           |$expected
           |""".stripMargin)
   }
+}
+
+removeFile := {
+  val actualPath = (scalaSource.in(Compile).value / "HasNoHeader.scala")
+  Files.delete(actualPath.toPath)
 }
 


### PR DESCRIPTION
The previous cache incantation one would throw an exception when removing a file
previosly seen and modified by the createHeader.