### PR TITLE
Add tasks to run `headerCreate` and `headerCheck` in all configurations

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,12 @@
 addSbtPlugin("com.dwijnand"      % "sbt-dynver"   % "4.0.0")
 addSbtPlugin("com.dwijnand"      % "sbt-travisci" % "1.2.0")
-addSbtPlugin("de.heikoseeberger" % "sbt-header"   % "5.3.0")
 addSbtPlugin("org.foundweekends" % "sbt-bintray"  % "0.5.5")
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt" % "2.2.1")
 
 libraryDependencies ++= Seq(
   "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value,
 )
+
+// For using the plugin in their own build
+unmanagedSourceDirectories in Compile +=
+  baseDirectory.in(ThisBuild).value.getParentFile / "src" / "main" / "scala"

--- a/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala
@@ -25,10 +25,12 @@ import sbt.{
   Configuration,
   File,
   Logger,
+  ScopeFilter,
   Setting,
   SettingKey,
   TaskKey,
   Test,
+  inAnyConfiguration,
   inConfig,
   settingKey,
   taskKey
@@ -83,8 +85,14 @@ object HeaderPlugin extends AutoPlugin {
     val headerCreate: TaskKey[Iterable[File]] =
       taskKey[Iterable[File]]("Create/update headers")
 
+    val headerCreateAll: TaskKey[Iterable[File]] =
+      taskKey[Iterable[File]]("Create/update headers in all configurations")
+
     val headerCheck: TaskKey[Iterable[File]] =
       taskKey[Iterable[File]]("Check whether files have headers")
+
+    val headerCheckAll: TaskKey[Iterable[File]] =
+      taskKey[Iterable[File]]("Check whether files have headers in all configurations")
 
     def headerSettings(configurations: Configuration*): Seq[Setting[_]] =
       configurations.foldLeft(List.empty[Setting[_]]) { _ ++ inConfig(_)(toBeScopedSettings) }
@@ -121,6 +129,7 @@ object HeaderPlugin extends AutoPlugin {
           headerEmptyLine.value,
           streams.value.log
         ),
+      headerCreateAll := headerCreate.?.all(ScopeFilter(configurations = inAnyConfiguration)).value.flatten.flatten.toSet,
       headerCheck := checkHeadersTask(
           headerSources.value.toList ++
           headerResources.value.toList,
@@ -128,7 +137,8 @@ object HeaderPlugin extends AutoPlugin {
           headerMappings.value,
           headerEmptyLine.value,
           streams.value.log
-        )
+        ),
+      headerCheckAll := headerCheck.?.all(ScopeFilter(configurations = inAnyConfiguration)).value.flatten.flatten.toSet
     )
 
   private def notToBeScopedSettings =

--- a/src/sbt-test/sbt-header/checkHeaders-all/project/test.sbt
+++ b/src/sbt-test/sbt-header/checkHeaders-all/project/test.sbt
@@ -1,0 +1,5 @@
+val pluginVersion = sys.props
+  .get("plugin.version")
+  .getOrElse(sys.error("Sys prop plugin.version must be defined!"))
+
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % pluginVersion)

--- a/src/sbt-test/sbt-header/checkHeaders-all/src/main/scala/HasHeader.scala
+++ b/src/sbt-test/sbt-header/checkHeaders-all/src/main/scala/HasHeader.scala
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+class HasHeader

--- a/src/sbt-test/sbt-header/checkHeaders-all/src/test/scala/HasHeader.scala
+++ b/src/sbt-test/sbt-header/checkHeaders-all/src/test/scala/HasHeader.scala
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+class HasHeader

--- a/src/sbt-test/sbt-header/checkHeaders-all/test
+++ b/src/sbt-test/sbt-header/checkHeaders-all/test
@@ -1,0 +1,2 @@
+# check headers and expect no build failure
+> headerCheck

--- a/src/sbt-test/sbt-header/checkHeaders-all/test.sbt
+++ b/src/sbt-test/sbt-header/checkHeaders-all/test.sbt
@@ -1,0 +1,1 @@
+headerLicense := Some(HeaderLicense.ALv2("2015", "Heiko Seeberger"))

--- a/src/sbt-test/sbt-header/checkHeaders-fails-all/project/test.sbt
+++ b/src/sbt-test/sbt-header/checkHeaders-fails-all/project/test.sbt
@@ -1,0 +1,5 @@
+val pluginVersion = sys.props
+  .get("plugin.version")
+  .getOrElse(sys.error("Sys prop plugin.version must be defined!"))
+
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % pluginVersion)

--- a/src/sbt-test/sbt-header/checkHeaders-fails-all/src/main/scala/HasHeader.scala
+++ b/src/sbt-test/sbt-header/checkHeaders-fails-all/src/main/scala/HasHeader.scala
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+class HasHeader

--- a/src/sbt-test/sbt-header/checkHeaders-fails-all/src/main/scala/HasNoHeader.scala
+++ b/src/sbt-test/sbt-header/checkHeaders-fails-all/src/main/scala/HasNoHeader.scala
@@ -1,0 +1,1 @@
+class HasNoHeader

--- a/src/sbt-test/sbt-header/checkHeaders-fails-all/src/test/scala/HasHeader.scala
+++ b/src/sbt-test/sbt-header/checkHeaders-fails-all/src/test/scala/HasHeader.scala
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+class HasHeader

--- a/src/sbt-test/sbt-header/checkHeaders-fails-all/src/test/scala/HasNoHeader.scala
+++ b/src/sbt-test/sbt-header/checkHeaders-fails-all/src/test/scala/HasNoHeader.scala
@@ -1,0 +1,1 @@
+class HasNoHeader

--- a/src/sbt-test/sbt-header/checkHeaders-fails-all/test
+++ b/src/sbt-test/sbt-header/checkHeaders-fails-all/test
@@ -1,0 +1,2 @@
+# check for headers and expect a build failure
+-> headerCheck

--- a/src/sbt-test/sbt-header/checkHeaders-fails-all/test.sbt
+++ b/src/sbt-test/sbt-header/checkHeaders-fails-all/test.sbt
@@ -1,0 +1,1 @@
+headerLicense := Some(HeaderLicense.ALv2("2015", "Heiko Seeberger"))

--- a/src/sbt-test/sbt-header/simple-all/project/test.sbt
+++ b/src/sbt-test/sbt-header/simple-all/project/test.sbt
@@ -1,0 +1,6 @@
+val pluginVersion =
+  sys.props
+    .get("plugin.version")
+    .getOrElse(sys.error("Sys prop plugin.version must be defined!"))
+
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % pluginVersion)

--- a/src/sbt-test/sbt-header/simple-all/src/main/resources/HasHeader.scala_expected
+++ b/src/sbt-test/sbt-header/simple-all/src/main/resources/HasHeader.scala_expected
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.heikoseeberger.sbtheader.test;
+
+class HasHeader

--- a/src/sbt-test/sbt-header/simple-all/src/main/resources/HasNoHeader.scala_expected
+++ b/src/sbt-test/sbt-header/simple-all/src/main/resources/HasNoHeader.scala_expected
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.heikoseeberger.sbtheader.test;
+
+class HasNoHeader

--- a/src/sbt-test/sbt-header/simple-all/src/main/scala/HasHeader.scala
+++ b/src/sbt-test/sbt-header/simple-all/src/main/scala/HasHeader.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.heikoseeberger.sbtheader.test;
+
+class HasHeader

--- a/src/sbt-test/sbt-header/simple-all/src/main/scala/HasNoHeader.scala
+++ b/src/sbt-test/sbt-header/simple-all/src/main/scala/HasNoHeader.scala
@@ -1,0 +1,3 @@
+package de.heikoseeberger.sbtheader.test;
+
+class HasNoHeader

--- a/src/sbt-test/sbt-header/simple-all/src/test/resources/HasHeader.scala_expected
+++ b/src/sbt-test/sbt-header/simple-all/src/test/resources/HasHeader.scala_expected
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.heikoseeberger.sbtheader.test;
+
+class HasHeader

--- a/src/sbt-test/sbt-header/simple-all/src/test/resources/HasNoHeader.scala_expected
+++ b/src/sbt-test/sbt-header/simple-all/src/test/resources/HasNoHeader.scala_expected
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.heikoseeberger.sbtheader.test;
+
+class HasNoHeader

--- a/src/sbt-test/sbt-header/simple-all/src/test/scala/HasHeader.scala
+++ b/src/sbt-test/sbt-header/simple-all/src/test/scala/HasHeader.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.heikoseeberger.sbtheader.test;
+
+class HasHeader

--- a/src/sbt-test/sbt-header/simple-all/src/test/scala/HasNoHeader.scala
+++ b/src/sbt-test/sbt-header/simple-all/src/test/scala/HasNoHeader.scala
@@ -1,0 +1,3 @@
+package de.heikoseeberger.sbtheader.test;
+
+class HasNoHeader

--- a/src/sbt-test/sbt-header/simple-all/test
+++ b/src/sbt-test/sbt-header/simple-all/test
@@ -1,0 +1,8 @@
+# check if headers get created
+-> headerCheckAll
+> headerCreateAll
+$ must-mirror src/main/scala/HasHeader.scala src/main/resources/HasHeader.scala_expected
+$ must-mirror src/main/scala/HasNoHeader.scala src/main/resources/HasNoHeader.scala_expected
+$ must-mirror src/test/scala/HasHeader.scala src/test/resources/HasHeader.scala_expected
+$ must-mirror src/test/scala/HasNoHeader.scala src/test/resources/HasNoHeader.scala_expected
+> headerCheckAll

--- a/src/sbt-test/sbt-header/simple-all/test.sbt
+++ b/src/sbt-test/sbt-header/simple-all/test.sbt
@@ -1,0 +1,1 @@
+headerLicense := Some(HeaderLicense.ALv2("2015", "Heiko Seeberger"))


### PR DESCRIPTION


# What has been done in this PR?

- Add two new tasks:
   - `headerCreateAll`: Runs `headerCreate` in all available configurations
   - `headerCheckAll`: Runs `headerCheck` in all available configurations
- Add scripted tests for both new tasks