### PR TITLE
Add latest SPDX indentifiers for GNU licenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,15 @@ The most common licenses have been pre-canned in [License](https://github.com/sb
 |[Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)|`Apache-2.0`|
 |[BSD 2 Clause](https://opensource.org/licenses/BSD-2-Clause)|`BSD-2-Clause`|
 |[BSD 3 Clause](https://opensource.org/licenses/BSD-3-Clause)|`BSD-3-Clause`|
-|[GNU General Public License v3](http://www.gnu.org/licenses/gpl-3.0.en.html)|`GPL-3.0`|
-|[GNU Lesser General Public License v3](http://www.gnu.org/licenses/lgpl-3.0.en.html)|`LGPL-3.0`|
-|[GNU Affero General Public License v3](https://www.gnu.org/licenses/agpl.html)|`AGPL-3.0`|
+|[GNU General Public License v3 or later](https://spdx.org/licenses/GPL-3.0-or-later.html)|`GPL-3.0-or-later`|
+|[GNU General Public License v3 only](https://spdx.org/licenses/GPL-3.0-only.html)|`GPL-3.0-only`|
+|[GNU General Public License v3 (deprecated)](https://spdx.org/licenses/GPL-3.0.html)|`GPL-3.0`|
+|[GNU Lesser General Public License v3 or later](https://spdx.org/licenses/LGPL-3.0-or-later.html)|`LGPL-3.0-or-later`|
+|[GNU Lesser General Public License v3 only](https://spdx.org/licenses/LGPL-3.0-only.html)|`LGPL-3.0-only`|
+|[GNU Lesser General Public License v3 (deprecated)](https://spdx.org/licenses/LGPL-3.0.html)|`LGPL-3.0`|
+|[GNU Affero General Public License v3 or later](https://spdx.org/licenses/AGPL-3.0-or-later.html)|`AGPL-3.0-or-later`|
+|[GNU Affero General Public License v3 only](https://spdx.org/licenses/AGPL-3.0-only.html)|`AGPL-3.0-only`|
+|[GNU Affero General Public License v3 (deprecated)](https://spdx.org/licenses/AGPL-3.0.html)|`AGPL-3.0`|
 |[MIT License](https://opensource.org/licenses/MIT)|`MIT`|
 |[Mozilla Public License, v. 2.0](http://mozilla.org/MPL/2.0/)|`MPL-2.0`|
 

--- a/src/main/scala/de/heikoseeberger/sbtheader/License.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/License.scala
@@ -32,7 +32,22 @@ sealed trait SpdxLicense {
 object License {
 
   private[sbtheader] val spdxLicenses =
-    Vector(ALv2, MIT, MPLv2, BSD2Clause, BSD3Clause, GPLv3, LGPLv3, AGPLv3)
+    Vector(
+      ALv2,
+      MIT,
+      MPLv2,
+      BSD2Clause,
+      BSD3Clause,
+      GPLv3OrLater,
+      GPLv3Only,
+      GPLv3,
+      LGPLv3OrLater,
+      LGPLv3Only,
+      LGPLv3,
+      AGPLv3OrLater,
+      AGPLv3Only,
+      AGPLv3
+    )
 
   private[sbtheader] def buildSpdxSyntax(
       yyyy: String,
@@ -239,6 +254,76 @@ object License {
     }
   }
 
+  final case object GPLv3OrLater extends SpdxLicense {
+
+    override def spdxIdentifier = "GPL-3.0-or-later"
+
+    override def apply(yyyy: String, copyrightOwner: String, licenseStyle: LicenseStyle) =
+      new GPLv3OrLater(yyyy, copyrightOwner, licenseStyle)
+
+    def detailed(yyyy: String, copyrightOwner: String) =
+      s"""|Copyright (C) $yyyy  $copyrightOwner
+          |
+          |This program is free software: you can redistribute it and/or modify
+          |it under the terms of the GNU General Public License as published by
+          |the Free Software Foundation, either version 3 of the License, or
+          |(at your option) any later version.
+          |
+          |This program is distributed in the hope that it will be useful,
+          |but WITHOUT ANY WARRANTY; without even the implied warranty of
+          |MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+          |GNU General Public License for more details.
+          |
+          |You should have received a copy of the GNU General Public License
+          |along with this program.  If not, see <http://www.gnu.org/licenses/>.
+          |""".stripMargin
+  }
+
+  final class GPLv3OrLater(yyyy: String, copyrightOwner: String, licenseStyle: LicenseStyle)
+      extends License {
+
+    override val text: String = licenseStyle match {
+      case SpdxSyntax =>
+        buildSpdxSyntax(yyyy, copyrightOwner, GPLv3OrLater.spdxIdentifier)
+
+      case Detailed =>
+        GPLv3OrLater.detailed(yyyy, copyrightOwner)
+    }
+  }
+
+  final case object GPLv3Only extends SpdxLicense {
+
+    override def spdxIdentifier = "GPL-3.0-only"
+
+    override def apply(yyyy: String, copyrightOwner: String, licenseStyle: LicenseStyle) =
+      new GPLv3Only(yyyy, copyrightOwner, licenseStyle)
+  }
+
+  final class GPLv3Only(yyyy: String, copyrightOwner: String, licenseStyle: LicenseStyle)
+      extends License {
+
+    override val text: String = licenseStyle match {
+      case SpdxSyntax =>
+        buildSpdxSyntax(yyyy, copyrightOwner, GPLv3Only.spdxIdentifier)
+
+      case Detailed =>
+        s"""|Copyright (C) $yyyy  $copyrightOwner
+            |
+            |This program is free software: you can redistribute it and/or modify
+            |it under the terms of the GNU General Public License as published by
+            |the Free Software Foundation, version 3.
+            |
+            |This program is distributed in the hope that it will be useful,
+            |but WITHOUT ANY WARRANTY; without even the implied warranty of
+            |MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+            |GNU General Public License for more details.
+            |
+            |You should have received a copy of the GNU General Public License
+            |along with this program.  If not, see <http://www.gnu.org/licenses/>.
+            |""".stripMargin
+    }
+  }
+
   final case object GPLv3 extends SpdxLicense {
 
     override def spdxIdentifier = "GPL-3.0"
@@ -255,19 +340,73 @@ object License {
         buildSpdxSyntax(yyyy, copyrightOwner, GPLv3.spdxIdentifier)
 
       case Detailed =>
+        GPLv3OrLater.detailed(yyyy, copyrightOwner)
+    }
+  }
+
+  final case object LGPLv3OrLater extends SpdxLicense {
+
+    override def spdxIdentifier = "LGPL-3.0-or-later"
+
+    override def apply(yyyy: String, copyrightOwner: String, licenseStyle: LicenseStyle) =
+      new LGPLv3OrLater(yyyy, copyrightOwner, licenseStyle)
+
+    def detailed(yyyy: String, copyrightOwner: String) =
+      s"""|Copyright (C) $yyyy  $copyrightOwner
+          |
+          |This program is free software: you can redistribute it and/or modify
+          |it under the terms of the GNU Lesser General Public License as published
+          |by the Free Software Foundation, either version 3 of the License, or
+          |(at your option) any later version.
+          |
+          |This program is distributed in the hope that it will be useful,
+          |but WITHOUT ANY WARRANTY; without even the implied warranty of
+          |MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+          |GNU Lesser General Public License for more details.
+          |
+          |You should have received a copy of the GNU General Lesser Public License
+          |along with this program.  If not, see <http://www.gnu.org/licenses/>.
+          |""".stripMargin
+  }
+
+  final class LGPLv3OrLater(yyyy: String, copyrightOwner: String, licenseStyle: LicenseStyle)
+      extends License {
+    override val text: String = licenseStyle match {
+      case SpdxSyntax =>
+        buildSpdxSyntax(yyyy, copyrightOwner, LGPLv3OrLater.spdxIdentifier)
+
+      case Detailed =>
+        LGPLv3OrLater.detailed(yyyy, copyrightOwner)
+    }
+  }
+
+  final case object LGPLv3Only extends SpdxLicense {
+
+    override def spdxIdentifier = "LGPL-3.0-only"
+
+    override def apply(yyyy: String, copyrightOwner: String, licenseStyle: LicenseStyle) =
+      new LGPLv3Only(yyyy, copyrightOwner, licenseStyle)
+  }
+
+  final class LGPLv3Only(yyyy: String, copyrightOwner: String, licenseStyle: LicenseStyle)
+      extends License {
+    override val text: String = licenseStyle match {
+      case SpdxSyntax =>
+        buildSpdxSyntax(yyyy, copyrightOwner, LGPLv3Only.spdxIdentifier)
+
+      case Detailed =>
         s"""|Copyright (C) $yyyy  $copyrightOwner
             |
             |This program is free software: you can redistribute it and/or modify
-            |it under the terms of the GNU General Public License as published by
-            |the Free Software Foundation, either version 3 of the License, or
-            |(at your option) any later version.
+            |it under the terms of the GNU Lesser General Public License as published
+            |by the Free Software Foundation, version 3.
             |
             |This program is distributed in the hope that it will be useful,
             |but WITHOUT ANY WARRANTY; without even the implied warranty of
             |MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-            |GNU General Public License for more details.
+            |GNU Lesser General Public License for more details.
             |
-            |You should have received a copy of the GNU General Public License
+            |You should have received a copy of the GNU General Lesser Public License
             |along with this program.  If not, see <http://www.gnu.org/licenses/>.
             |""".stripMargin
     }
@@ -288,19 +427,73 @@ object License {
         buildSpdxSyntax(yyyy, copyrightOwner, LGPLv3.spdxIdentifier)
 
       case Detailed =>
+        LGPLv3OrLater.detailed(yyyy, copyrightOwner)
+    }
+  }
+
+  final case object AGPLv3OrLater extends SpdxLicense {
+    override def spdxIdentifier = "AGPL-3.0-or-later"
+
+    override def apply(yyyy: String, copyrightOwner: String, licenseStyle: LicenseStyle) =
+      new AGPLv3OrLater(yyyy, copyrightOwner, licenseStyle)
+
+    def detailed(yyyy: String, copyrightOwner: String) =
+      s"""|Copyright (C) $yyyy  $copyrightOwner
+          |
+          |This program is free software: you can redistribute it and/or modify
+          |it under the terms of the GNU Affero General Public License as
+          |published by the Free Software Foundation, either version 3 of the
+          |License, or (at your option) any later version.
+          |
+          |This program is distributed in the hope that it will be useful,
+          |but WITHOUT ANY WARRANTY; without even the implied warranty of
+          |MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+          |GNU Affero General Public License for more details.
+          |
+          |You should have received a copy of the GNU Affero General Public License
+          |along with this program.  If not, see <http://www.gnu.org/licenses/>.
+          |""".stripMargin
+  }
+
+  final class AGPLv3OrLater(yyyy: String, copyrightOwner: String, licenseStyle: LicenseStyle)
+      extends License {
+
+    override val text: String = licenseStyle match {
+      case SpdxSyntax =>
+        buildSpdxSyntax(yyyy, copyrightOwner, AGPLv3OrLater.spdxIdentifier)
+
+      case Detailed =>
+        AGPLv3OrLater.detailed(yyyy, copyrightOwner)
+    }
+  }
+
+  final case object AGPLv3Only extends SpdxLicense {
+    override def spdxIdentifier = "AGPL-3.0-only"
+
+    override def apply(yyyy: String, copyrightOwner: String, licenseStyle: LicenseStyle) =
+      new AGPLv3Only(yyyy, copyrightOwner, licenseStyle)
+  }
+
+  final class AGPLv3Only(yyyy: String, copyrightOwner: String, licenseStyle: LicenseStyle)
+      extends License {
+
+    override val text: String = licenseStyle match {
+      case SpdxSyntax =>
+        buildSpdxSyntax(yyyy, copyrightOwner, AGPLv3Only.spdxIdentifier)
+
+      case Detailed =>
         s"""|Copyright (C) $yyyy  $copyrightOwner
             |
             |This program is free software: you can redistribute it and/or modify
-            |it under the terms of the GNU Lesser General Public License as published
-            |by the Free Software Foundation, either version 3 of the License, or
-            |(at your option) any later version.
+            |it under the terms of the GNU Affero General Public License as
+            |published by the Free Software Foundation, version 3.
             |
             |This program is distributed in the hope that it will be useful,
             |but WITHOUT ANY WARRANTY; without even the implied warranty of
             |MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-            |GNU Lesser General Public License for more details.
+            |GNU Affero General Public License for more details.
             |
-            |You should have received a copy of the GNU General Lesser Public License
+            |You should have received a copy of the GNU Affero General Public License
             |along with this program.  If not, see <http://www.gnu.org/licenses/>.
             |""".stripMargin
     }
@@ -321,21 +514,7 @@ object License {
         buildSpdxSyntax(yyyy, copyrightOwner, AGPLv3.spdxIdentifier)
 
       case Detailed =>
-        s"""|Copyright (C) $yyyy  $copyrightOwner
-            |
-            |This program is free software: you can redistribute it and/or modify
-            |it under the terms of the GNU Affero General Public License as
-            |published by the Free Software Foundation, either version 3 of the
-            |License, or (at your option) any later version.
-            |
-            |This program is distributed in the hope that it will be useful,
-            |but WITHOUT ANY WARRANTY; without even the implied warranty of
-            |MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-            |GNU Affero General Public License for more details.
-            |
-            |You should have received a copy of the GNU Affero General Public License
-            |along with this program.  If not, see <http://www.gnu.org/licenses/>.
-            |""".stripMargin
+        AGPLv3OrLater.detailed(yyyy, copyrightOwner)
     }
   }
 

--- a/src/test/scala/de/heikoseeberger/sbtheader/LicenseDetectionSpec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/LicenseDetectionSpec.scala
@@ -36,13 +36,31 @@ class LicenseDetectionSpec extends WordSpec with Matchers {
     BSD3Clause(yyyy.toString, organizationName) -> ("BSD-3-Clause", new URL(
       "https://spdx.org/licenses/BSD-3-Clause.html#licenseText"
     )),
+    AGPLv3OrLater(yyyy.toString, organizationName) -> ("AGPL-3.0-or-later", new URL(
+      "https://spdx.org/licenses/AGPL-3.0-or-later.html#licenseText"
+    )),
+    AGPLv3Only(yyyy.toString, organizationName) -> ("AGPL-3.0-only", new URL(
+      "https://spdx.org/licenses/AGPL-3.0-only.html#licenseText"
+    )),
     AGPLv3(yyyy.toString, organizationName) -> ("AGPL-3.0", new URL(
       "https://spdx.org/licenses/AGPL-3.0.html#licenseText"
     )),
     ALv2(yyyy.toString, organizationName) ->
     apache,
+    GPLv3OrLater(yyyy.toString, organizationName) -> ("GPL-3.0-or-later", new URL(
+      "https://spdx.org/licenses/GPL-3.0-or-later.html#licenseText"
+    )),
+    GPLv3Only(yyyy.toString, organizationName) -> ("GPL-3.0-only", new URL(
+      "https://spdx.org/licenses/GPL-3.0-only.html#licenseText"
+    )),
     GPLv3(yyyy.toString, organizationName) -> ("GPL-3.0", new URL(
       "https://spdx.org/licenses/GPL-3.0.html#licenseText"
+    )),
+    LGPLv3OrLater(yyyy.toString, organizationName) -> ("LGPL-3.0-or-later", new URL(
+      "https://spdx.org/licenses/LGPL-3.0-or-later.html#licenseText"
+    )),
+    LGPLv3Only(yyyy.toString, organizationName) -> ("LGPL-3.0-only", new URL(
+      "https://spdx.org/licenses/LGPL-3.0-only.html#licenseText"
     )),
     LGPLv3(yyyy.toString, organizationName) -> ("LGPL-3.0", new URL(
       "https://spdx.org/licenses/LGPL-3.0.html#licenseText"

--- a/src/test/scala/de/heikoseeberger/sbtheader/LicenseSpec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/LicenseSpec.scala
@@ -19,7 +19,56 @@ package de.heikoseeberger.sbtheader
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.HeaderLicense._
 import org.scalatest.{ Matchers, WordSpec }
 
-class LicenseSpec extends WordSpec with Matchers {
+class licenseSpec extends WordSpec with Matchers {
+
+  "AGPLv3OrLater" should {
+
+    "contain the AGPLv3 or later license with the given copyright year and owner" in {
+      val agplv3 = AGPLv3OrLater("2020", "Edward Samson").text
+      val expected =
+        s"""|Copyright (C) 2020  Edward Samson
+            |
+            |This program is free software: you can redistribute it and/or modify
+            |it under the terms of the GNU Affero General Public License as
+            |published by the Free Software Foundation, either version 3 of the
+            |License, or (at your option) any later version.
+            |
+            |This program is distributed in the hope that it will be useful,
+            |but WITHOUT ANY WARRANTY; without even the implied warranty of
+            |MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+            |GNU Affero General Public License for more details.
+            |
+            |You should have received a copy of the GNU Affero General Public License
+            |along with this program.  If not, see <http://www.gnu.org/licenses/>.
+            |""".stripMargin
+
+      agplv3 shouldBe expected
+    }
+  }
+
+  "AGPLv3Only" should {
+
+    "contain the AGPLv3 only license with the given copyright year and owner" in {
+      val agplv3 = AGPLv3Only("2020", "Edward Samson").text
+      val expected =
+        s"""|Copyright (C) 2020  Edward Samson
+            |
+            |This program is free software: you can redistribute it and/or modify
+            |it under the terms of the GNU Affero General Public License as
+            |published by the Free Software Foundation, version 3.
+            |
+            |This program is distributed in the hope that it will be useful,
+            |but WITHOUT ANY WARRANTY; without even the implied warranty of
+            |MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+            |GNU Affero General Public License for more details.
+            |
+            |You should have received a copy of the GNU Affero General Public License
+            |along with this program.  If not, see <http://www.gnu.org/licenses/>.
+            |""".stripMargin
+
+      agplv3 shouldBe expected
+    }
+  }
 
   "AGPLv3" should {
 
@@ -142,6 +191,55 @@ class LicenseSpec extends WordSpec with Matchers {
     }
   }
 
+  "GPLv3OrLater" should {
+
+    "contain the GPLv3 or later license with the given copyright year and owner" in {
+      val gplv3 = GPLv3OrLater("2020", "Edward Samson").text
+      val expected =
+        s"""|Copyright (C) 2020  Edward Samson
+            |
+            |This program is free software: you can redistribute it and/or modify
+            |it under the terms of the GNU General Public License as published by
+            |the Free Software Foundation, either version 3 of the License, or
+            |(at your option) any later version.
+            |
+            |This program is distributed in the hope that it will be useful,
+            |but WITHOUT ANY WARRANTY; without even the implied warranty of
+            |MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+            |GNU General Public License for more details.
+            |
+            |You should have received a copy of the GNU General Public License
+            |along with this program.  If not, see <http://www.gnu.org/licenses/>.
+            |""".stripMargin
+
+      gplv3 shouldBe expected
+    }
+  }
+
+  "GPLv3Only" should {
+
+    "contain the GPLv3 only license with the given copyright year and owner" in {
+      val gplv3 = GPLv3Only("2020", "Edward Samson").text
+      val expected =
+        s"""|Copyright (C) 2020  Edward Samson
+            |
+            |This program is free software: you can redistribute it and/or modify
+            |it under the terms of the GNU General Public License as published by
+            |the Free Software Foundation, version 3.
+            |
+            |This program is distributed in the hope that it will be useful,
+            |but WITHOUT ANY WARRANTY; without even the implied warranty of
+            |MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+            |GNU General Public License for more details.
+            |
+            |You should have received a copy of the GNU General Public License
+            |along with this program.  If not, see <http://www.gnu.org/licenses/>.
+            |""".stripMargin
+
+      gplv3 shouldBe expected
+    }
+  }
+
   "GPLv3" should {
 
     "contain the GPLv3 license with the given copyright year and owner" in {
@@ -164,6 +262,55 @@ class LicenseSpec extends WordSpec with Matchers {
             |""".stripMargin
 
       gplv3 shouldBe expected
+    }
+  }
+
+  "LGPLv3OrLater" should {
+
+    "contain the LGPLv3 or later license with the given copyright year and owner" in {
+      val lgplv3 = LGPLv3OrLater("2020", "Edward Samson").text
+      val expected =
+        s"""|Copyright (C) 2020  Edward Samson
+            |
+            |This program is free software: you can redistribute it and/or modify
+            |it under the terms of the GNU Lesser General Public License as published
+            |by the Free Software Foundation, either version 3 of the License, or
+            |(at your option) any later version.
+            |
+            |This program is distributed in the hope that it will be useful,
+            |but WITHOUT ANY WARRANTY; without even the implied warranty of
+            |MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+            |GNU Lesser General Public License for more details.
+            |
+            |You should have received a copy of the GNU General Lesser Public License
+            |along with this program.  If not, see <http://www.gnu.org/licenses/>.
+            |""".stripMargin
+
+      lgplv3 shouldBe expected
+    }
+  }
+
+  "LGPLv3Only" should {
+
+    "contain the LGPLv3 only license with the given copyright year and owner" in {
+      val lgplv3 = LGPLv3Only("2020", "Edward Samson").text
+      val expected =
+        s"""|Copyright (C) 2020  Edward Samson
+            |
+            |This program is free software: you can redistribute it and/or modify
+            |it under the terms of the GNU Lesser General Public License as published
+            |by the Free Software Foundation, version 3.
+            |
+            |This program is distributed in the hope that it will be useful,
+            |but WITHOUT ANY WARRANTY; without even the implied warranty of
+            |MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+            |GNU Lesser General Public License for more details.
+            |
+            |You should have received a copy of the GNU General Lesser Public License
+            |along with this program.  If not, see <http://www.gnu.org/licenses/>.
+            |""".stripMargin
+
+      lgplv3 shouldBe expected
     }
   }
 


### PR DESCRIPTION
The old indentifiers are deprecated as described in
https://www.gnu.org/licenses/identify-licenses-clearly.en.html

Fixes #178