### PR TITLE
Make `LicenseDetection` public and allow choosing license style

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,15 @@ If you want to use the following syntax:
    */
 ```
 
-You have to pass the style when defining the headerLicense attribute
+You have two possibilites:
+
+- If you are using auto-detection, you just need to add the following to your `build.sbt`
+
+```sbt
+headerLicenseStyle := HeaderLicenseStyle.SpdxSyntax
+```
+
+- On the other hand, if you are defining your license explicitly, you'll have to pass the style when defining the `headerLicense` attribute:
 
 ```scala
 headerLicense := Some(HeaderLicense.MIT("2015", "Heiko Seeberger", HeaderLicenseStyle.SpdxSyntax))

--- a/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala
@@ -150,7 +150,7 @@ object HeaderPlugin extends AutoPlugin {
       headerLicense := LicenseDetection(
           licenses.value.toList,
           organizationName.value,
-          startYear.value
+          startYear.value.map(_.toString)
         ),
       includeFilter.in(headerSources) := includeFilter.in(unmanagedSources).value,
       excludeFilter.in(headerSources) := excludeFilter.in(unmanagedSources).value,

--- a/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala
@@ -68,6 +68,10 @@ object HeaderPlugin extends AutoPlugin {
         "The license to apply to files; None by default (enabling auto detection from project settings)"
       )
 
+    val headerLicenseStyle: SettingKey[LicenseStyle] = settingKey[LicenseStyle] {
+      "The license style to be used. Can be `Detailed` or `SpdxSyntax`. Defaults to Detailed."
+    }
+
     val headerMappings: SettingKey[Map[FileType, CommentStyle]] =
       settingKey(
         "CommentStyles to be used by file extension they should be applied to; C style block comments for Scala and Java files by default"
@@ -150,8 +154,10 @@ object HeaderPlugin extends AutoPlugin {
       headerLicense := LicenseDetection(
           licenses.value.toList,
           organizationName.value,
-          startYear.value.map(_.toString)
+          startYear.value.map(_.toString),
+          headerLicenseStyle.value
         ),
+      headerLicenseStyle := LicenseStyle.Detailed,
       includeFilter.in(headerSources) := includeFilter.in(unmanagedSources).value,
       excludeFilter.in(headerSources) := excludeFilter.in(unmanagedSources).value,
       includeFilter.in(headerResources) := includeFilter.in(unmanagedResources).value,

--- a/src/main/scala/de/heikoseeberger/sbtheader/LicenseDetection.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/LicenseDetection.scala
@@ -19,7 +19,7 @@ package de.heikoseeberger.sbtheader
 import sbt.URL
 import scala.collection.breakOut
 
-private object LicenseDetection {
+object LicenseDetection {
 
   private val spdxMapping =
     License.spdxLicenses.map(l => (l.spdxIdentifier, l))(breakOut): Map[String, SpdxLicense]

--- a/src/main/scala/de/heikoseeberger/sbtheader/LicenseDetection.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/LicenseDetection.scala
@@ -27,7 +27,7 @@ private object LicenseDetection {
   def apply(
       licenses: Seq[(String, URL)],
       organizationName: String,
-      startYear: Option[Int]
+      startYear: Option[String]
   ): Option[License] = {
     val licenseName = licenses match {
       case (name, _) :: Nil => Some(name)
@@ -38,6 +38,6 @@ private object LicenseDetection {
       name    <- licenseName
       license <- spdxMapping.get(name)
       year    <- startYear
-    } yield license(year.toString, organizationName)
+    } yield license(year, organizationName)
   }
 }

--- a/src/main/scala/de/heikoseeberger/sbtheader/LicenseDetection.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/LicenseDetection.scala
@@ -27,7 +27,8 @@ object LicenseDetection {
   def apply(
       licenses: Seq[(String, URL)],
       organizationName: String,
-      startYear: Option[String]
+      startYear: Option[String],
+      licenseStyle: LicenseStyle = LicenseStyle.Detailed
   ): Option[License] = {
     val licenseName = licenses match {
       case (name, _) :: Nil => Some(name)
@@ -38,6 +39,6 @@ object LicenseDetection {
       name    <- licenseName
       license <- spdxMapping.get(name)
       year    <- startYear
-    } yield license(year, organizationName)
+    } yield license(year, organizationName, licenseStyle)
   }
 }

--- a/src/sbt-test/sbt-header/auto-detection-with-different-style/project/test.sbt
+++ b/src/sbt-test/sbt-header/auto-detection-with-different-style/project/test.sbt
@@ -1,0 +1,6 @@
+val pluginVersion =
+  sys.props
+    .get("plugin.version")
+    .getOrElse(sys.error("Sys prop plugin.version must be defined!"))
+
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % pluginVersion)

--- a/src/sbt-test/sbt-header/auto-detection-with-different-style/src/main/resources/HasNoHeader.scala_expected
+++ b/src/sbt-test/sbt-header/auto-detection-with-different-style/src/main/resources/HasNoHeader.scala_expected
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package de.heikoseeberger.sbtheader.test;
+
+class HasNoHeader

--- a/src/sbt-test/sbt-header/auto-detection-with-different-style/src/main/scala/HasNoHeader.scala
+++ b/src/sbt-test/sbt-header/auto-detection-with-different-style/src/main/scala/HasNoHeader.scala
@@ -1,0 +1,3 @@
+package de.heikoseeberger.sbtheader.test;
+
+class HasNoHeader

--- a/src/sbt-test/sbt-header/auto-detection-with-different-style/test
+++ b/src/sbt-test/sbt-header/auto-detection-with-different-style/test
@@ -1,0 +1,5 @@
+# check if headers get created with different style
+-> headerCheck
+> headerCreate
+$ must-mirror src/main/scala/HasNoHeader.scala src/main/resources/HasNoHeader.scala_expected
+> headerCheck

--- a/src/sbt-test/sbt-header/auto-detection-with-different-style/test.sbt
+++ b/src/sbt-test/sbt-header/auto-detection-with-different-style/test.sbt
@@ -1,0 +1,5 @@
+
+organizationName := "Heiko Seeberger"
+startYear := Some(2015)
+licenses := List(("Apache-2.0", new URL("https://www.apache.org/licenses/LICENSE-2.0.txt")))
+headerLicenseStyle := HeaderLicenseStyle.SpdxSyntax

--- a/src/test/scala/de/heikoseeberger/sbtheader/LicenseDetectionSpec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/LicenseDetectionSpec.scala
@@ -23,7 +23,7 @@ import sbt.URL
 class LicenseDetectionSpec extends WordSpec with Matchers {
 
   val organizationName = "Heiko Seeberger"
-  val yyyy             = 2017
+  val yyyy             = "2017"
   val startYear        = Some(yyyy)
   val apache: (String, URL) =
     ("Apache-2.0", new URL("https://spdx.org/licenses/Apache-2.0.html#licenseText"))

--- a/src/test/scala/de/heikoseeberger/sbtheader/LicenseDetectionSpec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/LicenseDetectionSpec.scala
@@ -92,6 +92,17 @@ class LicenseDetectionSpec extends WordSpec with Matchers {
       ) shouldBe None
     }
 
+    "allow changing license style" in {
+      val expected = ALv2(yyyy, organizationName, LicenseStyle.SpdxSyntax)
+
+      LicenseDetection(
+        List(apache),
+        organizationName,
+        startYear,
+        LicenseStyle.SpdxSyntax
+      ).map(_.text) shouldBe Some(expected.text)
+    }
+
     licenses.foreach {
       case (license, sbtLicense) =>
         s"detect ${license.getClass.getSimpleName} license" in {


### PR DESCRIPTION
# What has been done in this PR?

- Make `LicenseDetection` public so it can be used outside of this plugin, by third-party integrations.
- Change `LicenseDetection#startYear` to `String` so other values can be used (such as a year range).
- Add `LicenseStyle` parameter to `LicenseDetection`.
- Add new `headerLicenseStyle` setting to `HeaderPlugin` that `LicenseDetection` will use by default. It is backward compatible since the default value (`Detailed`) is also the default value of the different licenses constructors.