### PR TITLE
Add a simple `headerEndYear` key for configuring year ranges in license headers

### DIFF
--- a/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala
@@ -63,6 +63,11 @@ object HeaderPlugin extends AutoPlugin {
 
     val HeaderCommentStyle = CommentStyle
 
+    val headerEndYear: SettingKey[Option[Int]] =
+      settingKey(
+        "The end of the range of years to specify in the header. Defaults to None (only the `startYear` is used)."
+      )
+
     val headerLicense: SettingKey[Option[License]] =
       settingKey(
         "The license to apply to files; None by default (enabling auto detection from project settings)"
@@ -159,9 +164,11 @@ object HeaderPlugin extends AutoPlugin {
       headerLicense := LicenseDetection(
         licenses.value.toList,
         organizationName.value,
-        startYear.value.map(_.toString),
+        startYear.value,
+        headerEndYear.value,
         headerLicenseStyle.value
       ),
+      headerEndYear                   := None,
       headerLicenseStyle              := LicenseStyle.Detailed,
       headerSources / includeFilter   := (unmanagedSources / includeFilter).value,
       headerSources / excludeFilter   := (unmanagedSources / excludeFilter).value,

--- a/src/sbt-test/sbt-header/auto-detection-end-year/project/test.sbt
+++ b/src/sbt-test/sbt-header/auto-detection-end-year/project/test.sbt
@@ -1,0 +1,6 @@
+val pluginVersion =
+  sys.props
+    .get("plugin.version")
+    .getOrElse(sys.error("Sys prop plugin.version must be defined!"))
+
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % pluginVersion)

--- a/src/sbt-test/sbt-header/auto-detection-end-year/src/main/resources/HasNoHeader.scala_expected
+++ b/src/sbt-test/sbt-header/auto-detection-end-year/src/main/resources/HasNoHeader.scala_expected
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2015-2022 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.heikoseeberger.sbtheader.test;
+
+class HasNoHeader

--- a/src/sbt-test/sbt-header/auto-detection-end-year/src/main/scala/HasNoHeader.scala
+++ b/src/sbt-test/sbt-header/auto-detection-end-year/src/main/scala/HasNoHeader.scala
@@ -1,0 +1,3 @@
+package de.heikoseeberger.sbtheader.test;
+
+class HasNoHeader

--- a/src/sbt-test/sbt-header/auto-detection-end-year/test
+++ b/src/sbt-test/sbt-header/auto-detection-end-year/test
@@ -1,0 +1,5 @@
+# check if headers get created
+-> headerCheck
+> headerCreate
+> checkFileContents
+> headerCheck

--- a/src/sbt-test/sbt-header/auto-detection-end-year/test.sbt
+++ b/src/sbt-test/sbt-header/auto-detection-end-year/test.sbt
@@ -1,0 +1,26 @@
+organizationName := "Heiko Seeberger"
+startYear        := Some(2015)
+headerEndYear    := Some(2022)
+licenses         := List(("Apache-2.0", new URL("https://www.apache.org/licenses/LICENSE-2.0.txt")))
+
+val checkFileContents = taskKey[Unit]("Verify file contents match expected contents")
+
+checkFileContents := {
+  checkFile("HasNoHeader.scala")
+
+  def checkFile(name: String) = {
+    val actualPath   = (scalaSource.in(Compile).value / name).toString
+    val expectedPath = (resourceDirectory.in(Compile).value / s"${name}_expected").toString
+
+    val actual   = scala.io.Source.fromFile(actualPath).mkString
+    val expected = scala.io.Source.fromFile(expectedPath).mkString
+
+    if (actual != expected) sys.error(s"""|Actual file contents do not match expected file contents!
+          |  actual: $actualPath
+          |$actual
+          |
+          |  expected: $expectedPath
+          |$expected
+          |""".stripMargin)
+  }
+}

--- a/src/test/scala/de/heikoseeberger/sbtheader/LicenseDetectionSpec.scala
+++ b/src/test/scala/de/heikoseeberger/sbtheader/LicenseDetectionSpec.scala
@@ -104,6 +104,32 @@ class LicenseDetectionSpec extends AnyWordSpec with Matchers {
       ).map(_.text) shouldBe Some(expected.text)
     }
 
+    "use only the start year even when end year is set and equal" in {
+      val expected = ALv2(yyyy, organizationName, LicenseStyle.SpdxSyntax)
+
+      LicenseDetection(
+        List(apache),
+        organizationName,
+        startYear.map(_.toInt),
+        startYear.map(_.toInt),
+        LicenseStyle.SpdxSyntax
+      ).map(_.text) shouldBe Some(expected.text)
+    }
+
+    "detect end year when it is set and larger than start year" in {
+      val endYYYY  = yyyy.toInt + 2
+      val endYear  = Some(endYYYY)
+      val expected = ALv2(s"$yyyy-$endYYYY", organizationName, LicenseStyle.SpdxSyntax)
+
+      LicenseDetection(
+        List(apache),
+        organizationName,
+        startYear.map(_.toInt),
+        endYear,
+        LicenseStyle.SpdxSyntax
+      ).map(_.text) shouldBe Some(expected.text)
+    }
+
     licenses.foreach { case (license, sbtLicense) =>
       s"detect ${license.getClass.getSimpleName} license" in {
         LicenseDetection(List(sbtLicense), organizationName, startYear)


### PR DESCRIPTION
We're big fans of `sbt-header` in `sbt-typelevel` and would like to upstream this change that we use in our projects. It is a simple scheme for specifying an optional `headerEndYear`. The range resolution is done in a very simplistic way, but it goes very far in our projects.

Namely, `headerEndYear` is `None` by default, but if provided and is greater than the `startYear`, a range of the following format is constructed:
```scala
startYear := Some(2021)
headerEndYear := Some(2022)
```
results in `2021-2022` as the year range, which is then inserted into the license header as the year. In any other case, the `headerEndYear` is simply ignored.

Opening this PR to jumpstart a discussion. I'm of course open to making this scheme more general and I'm looking forward to proposed improvements.

Thanks in advance.