### PR TITLE
Allow passing endYear to LicenseDetection

### DIFF
--- a/src/main/scala/de/heikoseeberger/sbtheader/LicenseDetection.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/LicenseDetection.scala
@@ -32,7 +32,7 @@ object LicenseDetection {
   ): Option[License] =
     apply(licenses, organizationName, startYear.map(_.toInt), None, licenseStyle)
 
-  private[sbtheader] def apply(
+  def apply(
       licenses: Seq[(String, URL)],
       organizationName: String,
       startYear: Option[Int],


### PR DESCRIPTION
This PR allows passing the `endYear` val to the `apply` method of `LicenseDetection`.