### PR TITLE
Make `LicenseDetection.apply` public

### DIFF
--- a/src/main/scala/de/heikoseeberger/sbtheader/LicenseDetection.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/LicenseDetection.scala
@@ -32,7 +32,7 @@ object LicenseDetection {
   ): Option[License] =
     apply(licenses, organizationName, startYear.map(_.toInt), None, licenseStyle)
 
-  private[sbtheader] def apply(
+  def apply(
       licenses: Seq[(String, URL)],
       organizationName: String,
       startYear: Option[Int],


### PR DESCRIPTION
This method is being used in [sbt-github](https://github.com/alejandrohdezma/sbt-github/blob/9e0e2a202a94cf25a2b81d3a91ced063387ca92c/modules/sbt-github-header/src/main/scala/com/alejandrohdezma/sbt/github/sbtheader/SbtGithubHeaderPlugin.scala#L59) and the build is broken when updating to sbt-header `v5.8.0`.