### PR TITLE
Add new setting headerCopyrightOwner to use instead of `organizationName` for license detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ sbt-header is an [sbt](http://www.scala-sbt.org) plugin for creating or updating
 In order to add the sbt-header plugin to your build, add the following line to `project/plugins.sbt`:
 
 ``` scala
-addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.6.0") // Check the latest version above or look at the release tags
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.8.0") // Check the latest version above or look at the release tags
 ```
 
 Then in your `build.sbt` configure the following settings:

--- a/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala
@@ -68,6 +68,11 @@ object HeaderPlugin extends AutoPlugin {
         "The end of the range of years to specify in the header. Defaults to None (only the `startYear` is used)."
       )
 
+    val headerCopyrightOwner: SettingKey[String] =
+      settingKey(
+        "The copyright owner for the header. Defaults to the value for `organizationName`."
+      )
+
     val headerLicense: SettingKey[Option[License]] =
       settingKey(
         "The license to apply to files; None by default (enabling auto detection from project settings)"
@@ -163,11 +168,12 @@ object HeaderPlugin extends AutoPlugin {
       ),
       headerLicense := LicenseDetection(
         licenses.value.toList,
-        organizationName.value,
+        headerCopyrightOwner.value,
         startYear.value,
         headerEndYear.value,
         headerLicenseStyle.value
       ),
+      headerCopyrightOwner            := organizationName.value,
       headerEndYear                   := None,
       headerLicenseStyle              := LicenseStyle.Detailed,
       headerSources / includeFilter   := (unmanagedSources / includeFilter).value,

--- a/src/sbt-test/sbt-header/auto-detection-copyright-owner/project/test.sbt
+++ b/src/sbt-test/sbt-header/auto-detection-copyright-owner/project/test.sbt
@@ -1,0 +1,6 @@
+val pluginVersion =
+  sys.props
+    .get("plugin.version")
+    .getOrElse(sys.error("Sys prop plugin.version must be defined!"))
+
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % pluginVersion)

--- a/src/sbt-test/sbt-header/auto-detection-copyright-owner/src/main/resources/HasNoHeader.scala_expected
+++ b/src/sbt-test/sbt-header/auto-detection-copyright-owner/src/main/resources/HasNoHeader.scala_expected
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2015 Heiko Seeberger <https://example.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.heikoseeberger.sbtheader.test;
+
+class HasNoHeader

--- a/src/sbt-test/sbt-header/auto-detection-copyright-owner/src/main/scala/HasNoHeader.scala
+++ b/src/sbt-test/sbt-header/auto-detection-copyright-owner/src/main/scala/HasNoHeader.scala
@@ -1,0 +1,3 @@
+package de.heikoseeberger.sbtheader.test;
+
+class HasNoHeader

--- a/src/sbt-test/sbt-header/auto-detection-copyright-owner/test
+++ b/src/sbt-test/sbt-header/auto-detection-copyright-owner/test
@@ -1,0 +1,5 @@
+# check if headers get created
+-> headerCheck
+> headerCreate
+> checkFileContents
+> headerCheck

--- a/src/sbt-test/sbt-header/auto-detection-copyright-owner/test.sbt
+++ b/src/sbt-test/sbt-header/auto-detection-copyright-owner/test.sbt
@@ -1,0 +1,26 @@
+organizationName     := "Should not be used"
+startYear            := Some(2015)
+headerCopyrightOwner := "Heiko Seeberger <https://example.com>"
+licenses := List(("Apache-2.0", new URL("https://www.apache.org/licenses/LICENSE-2.0.txt")))
+
+val checkFileContents = taskKey[Unit]("Verify file contents match expected contents")
+
+checkFileContents := {
+  checkFile("HasNoHeader.scala")
+
+  def checkFile(name: String) = {
+    val actualPath   = (scalaSource.in(Compile).value / name).toString
+    val expectedPath = (resourceDirectory.in(Compile).value / s"${name}_expected").toString
+
+    val actual   = scala.io.Source.fromFile(actualPath).mkString
+    val expected = scala.io.Source.fromFile(expectedPath).mkString
+
+    if (actual != expected) sys.error(s"""|Actual file contents do not match expected file contents!
+          |  actual: $actualPath
+          |$actual
+          |
+          |  expected: $expectedPath
+          |$expected
+          |""".stripMargin)
+  }
+}


### PR DESCRIPTION
This change allows users to have headers like `My organization <myorganizationurl.com>`  without altering `organizationName` setting.

Defaults to `organizationName` so existent codebases do not break