### PR TITLE
Change groupid of `sbt-sassify`

### DIFF
--- a/bak/play-twirl/project/plugins.sbt
+++ b/bak/play-twirl/project/plugins.sbt
@@ -15,4 +15,4 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-mocha" % "1.1.0")
 
-addSbtPlugin("org.irundaia.sbt" % "sbt-sassify" % "1.4.6")
+addSbtPlugin("io.github.irundaia" % "sbt-sassify" % "1.5.2")


### PR DESCRIPTION
`sbt-sassify` lives under under a new groupId now.
See
* https://github.com/irundaia/sbt-sassify#usage
* https://repo1.maven.org/maven2/io/github/irundaia/sbt-sassify_2.12_1.0/

Older versions were hosted under https://repo.scala-sbt.org/ which is deprecated and should be avoided (it was down for a day in April...)