### PR TITLE
remove `final` modifier from `object`

### DIFF
--- a/src/main/scala/de/heikoseeberger/sbtheader/AutomateHeaderPlugin.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/AutomateHeaderPlugin.scala
@@ -26,7 +26,7 @@ import sbt.Keys.compile
   */
 object AutomateHeaderPlugin extends AutoPlugin {
 
-  final object autoImport {
+  object autoImport {
 
     def automateHeaderSettings(configurations: Configuration*): Seq[Setting[_]] =
       configurations.foldLeft(List.empty[Setting[_]]) {

--- a/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/HeaderPlugin.scala
@@ -44,13 +44,13 @@ import scala.util.matching.Regex
 
 object HeaderPlugin extends AutoPlugin {
 
-  final object autoImport {
+  object autoImport {
 
     val HeaderLicense = License
 
     val HeaderLicenseStyle = LicenseStyle
 
-    final object HeaderPattern {
+    object HeaderPattern {
 
       def commentBetween(start: String, middle: String, end: String): Regex =
         raw"""(?s)($start(?!\$middle).*?$end(?:\n|\r|\r\n)+)(.*)""".r

--- a/src/main/scala/de/heikoseeberger/sbtheader/License.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/License.scala
@@ -161,7 +161,7 @@ object License {
       }
   }
 
-  final object MPLv2_NoCopyright extends License {
+  object MPLv2_NoCopyright extends License {
 
     override val text: String =
       s"""|This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/main/scala/de/heikoseeberger/sbtheader/package.scala
+++ b/src/main/scala/de/heikoseeberger/sbtheader/package.scala
@@ -34,7 +34,7 @@ package object sbtheader {
       }
   }
 
-  private final object FileOps {
+  private object FileOps {
     val extensionPattern: Regex = """.+\.(.+)""".r
   }
 


### PR DESCRIPTION
prepare Scala 3, sbt 2.x build.

```
Welcome to Scala 3.3.4 (21.0.4, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                                                             
scala> final object A
1 warning found
-- [E147] Syntax Warning: ------------------------------------------------------
1 |final object A
  |^^^^^
  |Modifier final is redundant for this definition
```