### PR TITLE
fix `LicenseDetection.apply`

### DIFF
--- a/src/main/scala-2.12/LicenseDetection.scala
+++ b/src/main/scala-2.12/LicenseDetection.scala
@@ -31,8 +31,8 @@ object LicenseDetection {
   ): Option[License] = {
     val licenseName =
       licenses match {
-        case (name, _) :: Nil => Some(name)
-        case _                => None
+        case Seq((name, _)) => Some(name)
+        case _              => None
       }
 
     for {

--- a/src/main/scala-3/LicenseDetection.scala
+++ b/src/main/scala-3/LicenseDetection.scala
@@ -31,8 +31,8 @@ object LicenseDetection:
   ): Option[License] =
     val spdxIds =
       licenses match
-        case l :: Nil => Some(l.spdxId)
-        case _        => None
+        case Seq(l) => Some(l.spdxId)
+        case _      => None
     for
       spdxId  <- spdxIds
       license <- spdxMapping.get(spdxId)


### PR DESCRIPTION
Don't use `::.unapply` method for `Seq`

```
Welcome to Scala 2.12.20 (OpenJDK 64-Bit Server VM, Java 21.0.8).
Type in expressions for evaluation. Or try :help.

scala> def seq1: Seq[Int] = List(2)
seq1: Seq[Int]

scala> seq1 match {
     |   case x :: Nil => "single"
     |   case _ => "other"
     | }
res0: String = single

scala> def seq2: Seq[Int] = Vector(2)
seq2: Seq[Int]

scala> seq2 match {
     |   case x :: Nil => "single"
     |   case _ => "other"
     | }
res1: String = other
```