### PR TITLE
fix warnings

### DIFF
--- a/src/main/scala/sbtheader/License.scala
+++ b/src/main/scala/sbtheader/License.scala
@@ -50,7 +50,7 @@ object License {
         |SPDX-License-Identifier: $spdxIdentifier
         |""".stripMargin
 
-  final case object ALv2 extends SpdxLicense {
+  case object ALv2 extends SpdxLicense {
 
     override val spdxIdentifier: String =
       "Apache-2.0"
@@ -85,7 +85,7 @@ object License {
       }
   }
 
-  final case object MIT extends SpdxLicense {
+  case object MIT extends SpdxLicense {
 
     override val spdxIdentifier: String =
       "MIT"
@@ -125,7 +125,7 @@ object License {
       }
   }
 
-  final case object MPLv2 extends SpdxLicense {
+  case object MPLv2 extends SpdxLicense {
 
     override val spdxIdentifier: String =
       "MPL-2.0"
@@ -161,7 +161,7 @@ object License {
           |""".stripMargin
   }
 
-  final case object BSD2Clause extends SpdxLicense {
+  case object BSD2Clause extends SpdxLicense {
 
     override val spdxIdentifier: String =
       "BSD-2-Clause"
@@ -206,7 +206,7 @@ object License {
       }
   }
 
-  final case object BSD3Clause extends SpdxLicense {
+  case object BSD3Clause extends SpdxLicense {
 
     override val spdxIdentifier: String =
       "BSD-3-Clause"
@@ -255,7 +255,7 @@ object License {
       }
   }
 
-  final case object GPLv3OrLater extends SpdxLicense {
+  case object GPLv3OrLater extends SpdxLicense {
 
     override val spdxIdentifier: String =
       "GPL-3.0-or-later"
@@ -291,7 +291,7 @@ object License {
       }
   }
 
-  final case object GPLv3Only extends SpdxLicense {
+  case object GPLv3Only extends SpdxLicense {
 
     override val spdxIdentifier: String =
       "GPL-3.0-only"
@@ -326,7 +326,7 @@ object License {
       }
   }
 
-  final case object GPLv3 extends SpdxLicense {
+  case object GPLv3 extends SpdxLicense {
 
     override val spdxIdentifier: String =
       "GPL-3.0"
@@ -345,7 +345,7 @@ object License {
       }
   }
 
-  final case object LGPLv3OrLater extends SpdxLicense {
+  case object LGPLv3OrLater extends SpdxLicense {
 
     override val spdxIdentifier: String =
       "LGPL-3.0-or-later"
@@ -381,7 +381,7 @@ object License {
       }
   }
 
-  final case object LGPLv3Only extends SpdxLicense {
+  case object LGPLv3Only extends SpdxLicense {
 
     override def spdxIdentifier: String =
       "LGPL-3.0-only"
@@ -416,7 +416,7 @@ object License {
       }
   }
 
-  final case object LGPLv3 extends SpdxLicense {
+  case object LGPLv3 extends SpdxLicense {
 
     override def spdxIdentifier: String =
       "LGPL-3.0"
@@ -435,7 +435,7 @@ object License {
       }
   }
 
-  final case object AGPLv3OrLater extends SpdxLicense {
+  case object AGPLv3OrLater extends SpdxLicense {
     override def spdxIdentifier: String =
       "AGPL-3.0-or-later"
 
@@ -470,7 +470,7 @@ object License {
       }
   }
 
-  final case object AGPLv3Only extends SpdxLicense {
+  case object AGPLv3Only extends SpdxLicense {
 
     override val spdxIdentifier: String =
       "AGPL-3.0-only"
@@ -505,7 +505,7 @@ object License {
       }
   }
 
-  final case object AGPLv3 extends SpdxLicense {
+  case object AGPLv3 extends SpdxLicense {
 
     override val spdxIdentifier: String =
       "AGPL-3.0"

--- a/src/main/scala/sbtheader/LicenseStyle.scala
+++ b/src/main/scala/sbtheader/LicenseStyle.scala
@@ -10,6 +10,6 @@ package sbtheader
 sealed trait LicenseStyle
 
 object LicenseStyle {
-  final case object Detailed   extends LicenseStyle
-  final case object SpdxSyntax extends LicenseStyle
+  case object Detailed   extends LicenseStyle
+  case object SpdxSyntax extends LicenseStyle
 }


### PR DESCRIPTION
```
[warn] -- [E147] Syntax Warning: /home/runner/work/sbt-header/sbt-header/src/main/scala/sbtheader/License.scala:53:2 
[warn] 53 |  final case object ALv2 extends SpdxLicense {
[warn]    |  ^^^^^
[warn]    |  Modifier final is redundant for this definition
[warn] -- [E147] Syntax Warning: /home/runner/work/sbt-header/sbt-header/src/main/scala/sbtheader/License.scala:88:2 
[warn] 88 |  final case object MIT extends SpdxLicense {
[warn]    |  ^^^^^
[warn]    |  Modifier final is redundant for this definition
```